### PR TITLE
Fix unicode decode err

### DIFF
--- a/pywhat/regex_identifier.py
+++ b/pywhat/regex_identifier.py
@@ -8,7 +8,7 @@ class RegexIdentifier:
     def __init__(self):
         path = "Data/regex.json"
         fullpath = os.path.join(os.path.dirname(os.path.abspath(__file__)), path)
-        with open(fullpath, "r") as myfile:
+        with open(fullpath, "r", encoding="utf8") as myfile:
             self.regexes = json.load(myfile)
 
     def check(self, text):


### PR DESCRIPTION
My system code page have problem when loading `Data/regex.json`, specifying `encoding="utf8"` fixed the issue.

<details>
<summary>Full error log</summary>

```
$ what "5f4dcc3b5aa765d61d8327deb882cf99"
Traceback (most recent call last):
  File "C:\Python37_64\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Python37_64\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "c:\testenv\Scripts\what.exe\__main__.py", line 7, in <module>
  File "c:\testenv\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "c:\testenv\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "c:\testenv\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\testenv\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "c:\testenv\lib\site-packages\pywhat\what.py", line 31, in main
    what_obj = What_Object()
  File "c:\testenv\lib\site-packages\pywhat\what.py", line 40, in __init__
    self.id = identifier.Identifier()
  File "c:\testenv\lib\site-packages\pywhat\identifier.py", line 10, in __init__
    self.regex_id = RegexIdentifier()
  File "c:\testenv\lib\site-packages\pywhat\regex_identifier.py", line 11, in __init__
    self.regexes = json.load(myfile)
  File "C:\Python37_64\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 693: illegal multibyte sequence
```

</details>