### PR TITLE
Recursion fixes

### DIFF
--- a/pywhat/printer.py
+++ b/pywhat/printer.py
@@ -1,11 +1,12 @@
 import json
+import os
 
 from rich.console import Console
 from rich.table import Table
 
 
 class Printing:
-    def pretty_print(self, text: dict):
+    def pretty_print(self, text: dict, text_input):
         console = Console(highlight=False)
 
         to_out = ""
@@ -27,8 +28,8 @@ class Printing:
             table.add_column("Identified as", overflow="fold")
             table.add_column("Description", overflow="fold")
 
-            if list(text["Regexes"].keys())[0] == text:
-                # if input was text, do not add a filename column
+            if os.path.isdir(text_input):
+                # if input is a folder, add a filename column
                 table.add_column("Filename", overflow="fold")
 
             for key, value in text["Regexes"].items():
@@ -56,18 +57,18 @@ class Printing:
                     if not description:
                         description = "None"
 
-                    if key == "text":
+                    if os.path.isdir(text_input):
                         table.add_row(
                             matched,
                             name,
                             description,
+                            filename,
                         )
                     else:
                         table.add_row(
                             matched,
                             name,
                             description,
-                            filename,
                         )
 
             console.print(to_out, table)

--- a/pywhat/what.py
+++ b/pywhat/what.py
@@ -99,7 +99,7 @@ def main(text_input, rarity, include_tags, exclude_tags):
     identified_output = what_obj.what_is_this(text_input)
 
     p = printer.Printing()
-    p.pretty_print(identified_output)
+    p.pretty_print(identified_output, text_input)
 
 
 class What_Object:


### PR DESCRIPTION
- [x] `Filename` name in the column is now actually there
- [x] `Filename` column is only printed if input is a folder
- [ ] Fix links
- [ ] `::` should not match as IPv6
- [ ] add quotes to example in `what.py`, line 83
- [ ] make JWT regex require one letter, so it no longer matches to IPv4 addresses