### PR TITLE
only_text is set to True by default, updated tests

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -21,7 +21,7 @@
        "Tags": [
          "Networking",
          "Website"
-      ]
+       ]
     },
     {
        "Name": "Bitcoin (₿) Wallet Address",
@@ -94,25 +94,27 @@
     {
       "Name": "Amazon Web Services Simple Storage (AWS S3) URL",
       "Regex": "(?i)^[https://]*s3\\.amazonaws.com[\/]+.*$|[a-zA-Z0-9_-]*\\.s3\\.amazonaws.com/.*$",
+      "plural_name": false,
       "Description": null,
       "Rarity": 1,
       "URL": null,
       "Tags": [
          "Internet",
          "Networking"
-      ]
-   },    
-   {
+       ]
+    },
+    {
       "Name": "Amazon Web Services Simple Storage (AWS S3) Internal URL",
       "Regex": "(?i)^s3://([^/]+)/(.*?([^/]+)/?)$",
+      "plural_name": false,
       "Description": "Internal URL, only accessible via the virtual private cloud.",
       "Rarity": 1,
       "URL": null,
       "Tags": [
          "Internet",
          "Networking"
-      ]
-   },
+       ]
+    },
     {
        "Name": "Internet Protocol (IP) Address Version 6",
        "Regex": "(?=.*[0-9])\\[?(?:(?:[0-9a-f]{1,4}:){7,7}[0-9a-f]{1,4}|([0-9a-f]{4}:){1,7}:|([0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}|([0-9a-f]{1,4}:){1,5}(:[0-9a-f]{1,4}){1,2}|([0-9a-f]{1,4}:){1,4}(:[0-9a-f]{1,4}){1,3}|([0-9a-f]{1,4}:){1,3}(:[0-9a-f]{1,4}){1,4}|([0-9a-fA]{1,4}:){1,2}(:[0-9a-f]{1,4}){1,5}|[0-9a-f]{1,4}:((:[0-9a-f]{1,4}){1,6})|:((:[0-9a-f]{1,4}){1,7}|:)|fe80:(:[0-9a-f]{0,4}){0,4}%[0-9a-z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|(?:[0-9a-f]{1,4}:){1,4}:(?:(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\\]?(?::[0-9]{1,5})?",
@@ -124,7 +126,7 @@
           "Identifiers",
           "Networking"
        ]
-    },    
+    },
     {
       "Name": "Amazon Resource Name (ARN)",
       "Regex": "(?i)^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$",
@@ -136,8 +138,8 @@
          "Identifiers",
          "Networking",
          "AWS"
-      ]
-   },
+       ]
+    },
     {
        "Name": "Uniform Resource Locator (URL)",
        "Regex": "(?i)^(?:(?:(?:https?|ftp):)?\/\/)(?:\\S+(?::\\S*)?@?)?(?:(?!(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]?\\.?)+?(?:[a-z\u00a1-\uffff]+\\.?))(?::\\d{2,5})?(?:[\/?#]\\S*)?$",
@@ -170,7 +172,7 @@
        "URL": "https://www.google.com/maps/place/",
        "Tags": [
           "Geo-location"
-      ]
+       ]
     },
     {
        "Name": "Dogecoin (DOGE) Wallet Address",
@@ -223,6 +225,7 @@
     {
       "Name": "JSON Web Token (JWT)",
       "Regex": "(?i)^(?=.*[a-z])(?=.*[0-9])(?:[a-z0-9_=]+\\.){2}(?:[a-z0-9_\\-\\+\/=]*)$",
+      "plural_name": false,
       "Description": null,
       "Rarity": 0.5,
       "URL": null,
@@ -231,9 +234,9 @@
          "Hacking",
          "Token",
          "Website"
-      ]
-   },
-   {
+       ]
+    },
+    {
        "Name": "American Express Card Number",
        "Regex": "^3[47][0-9]{2}\\s?(?:[0-9]{4}\\s?){2}[0-9]{3}$",
        "plural_name": false,
@@ -470,6 +473,6 @@
          "Credentials",
          "Password",
          "Username"
-      ]
-   }
+       ]
+    }
 ]

--- a/pywhat/identifier.py
+++ b/pywhat/identifier.py
@@ -31,7 +31,7 @@ class Identifier:
         self,
         text: str,
         *,
-        only_text=False,
+        only_text=True,
         dist: Distribution = None,
         key: Optional[Callable] = None,
         reverse: Optional[bool] = None

--- a/pywhat/what.py
+++ b/pywhat/what.py
@@ -126,7 +126,7 @@ class What_Object:
         """
         Returns a Python dictionary of everything that has been identified
         """
-        return self.id.identify(text)
+        return self.id.identify(text, only_text=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -1,14 +1,12 @@
-import json
 import re
 
 from pywhat import identifier
 from pywhat.distribution import Distribution
-from pywhat.helper import Keys
+from pywhat.helper import Keys, load_regexes
 
 
 def test_check_keys_in_json():
-    with open("pywhat/Data/regex.json", "r") as file:
-        database = json.load(file)
+    database = load_regexes()
 
     for entry in database:
         keys = list(entry.keys())

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -137,5 +137,5 @@ def test_recursion():
     r = identifier.Identifier()
     out = r.identify("fixtures", only_text=False)
 
-    assert re.findall(r"\'(?:\/|\\)file\'", str(list(out["Regexes"].keys())))
-    assert re.findall(r"\'(?:\/|\\)test(?:\/|\\)file\'", str(list(out["Regexes"].keys())))
+    assert re.findall(r"\'(?:\/|\\\\)file\'", str(list(out["Regexes"].keys())))
+    assert re.findall(r"\'(?:\/|\\\\)test(?:\/|\\\\)file\'", str(list(out["Regexes"].keys())))


### PR DESCRIPTION
- `only_text` is now by default `True`, so if a user wants API to scan a file/folder, they will need to set it to `False`
- updated my recursion test - it worked really well, but it would always succeed
- added a new test that is checking if all keys are present in each JSON object - it showed that 3 were missing `plural_name`