### PR TITLE
Add regex for various API keys

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -164,6 +164,171 @@
        ]
     },
     {
+      "Name": "Google API Key",
+      "Regex": "AIza[0-9A-Za-z-_]{35}",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials",
+         "Google"
+      ]
+    },
+    {
+      "Name": "Google ReCaptcha API Key",
+      "Regex": "6L[0-9A-Za-z-_]{38}|^6[0-9a-zA-Z_-]{39}$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials",
+         "Google"
+      ]
+   },
+   {
+      "Name": "Google OAuth Token",
+      "Regex": "ya29.[0-9A-Za-z-_]+",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials",
+         "Google"
+      ]
+   },
+   {
+      "Name": "AWS Access Key ID",
+      "Regex": "A[SK]IA[0-9A-Z]{16}",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials",
+         "AWS"
+      ]
+   },
+    {
+      "Name": "Mailgun API Key",
+      "Regex": "key-[0-9a-zA-Z]{32}",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials"
+      ]
+   },
+   {
+      "Name": "Twilio API Key",
+      "Regex": "SK[0-9a-fA-F]{32}",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials",
+         "Twilio"
+     ]
+   },
+   {
+      "Name": "Twilio Account SID",
+      "Regex": "AC[a-zA-Z0-9_-]{32}",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials",
+         "Twilio"
+      ]
+   },
+   {
+      "Name": "Twilio Application SID",
+      "Regex": "AP[a-zA-Z0-9_-]{32}",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials",
+         "Twilio"
+      ]
+   },
+    {
+      "Name": "Square Application Secret",
+      "Regex": "sandbox-?sq0csp-[0-9A-Za-z-_]{43}|sq0[a-z]{3}-[0-9A-Za-z-_]{22,43}",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials",
+         "Square"
+      ]
+   },
+   {
+      "Name": "Square Access Token",
+      "Regex": "sqOatp-[0-9A-Za-z-_]{22}|EAAA[a-zA-Z0-9-_]{60}",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials",
+         "Square"
+      ]
+   },
+   {
+      "Name": "Stripe API Key",
+      "Regex": "[srp]k_live_[0-9a-zA-Z]{24}",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials"
+      ]
+    },
+    {
+      "Name": "GitHub Access Token",
+      "Regex": "[a-zA-Z0-9_-]*:[a-zA-Z0-9_-]+@github.com*",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials"
+      ]
+    },
+    {
+      "Name": "Slack Token",
+      "Regex": "xox[a-zA-Z]-[a-zA-Z0-9-]+",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Credentials"
+      ]
+    },
+    {
       "Name": "Amazon Resource Name (ARN)",
       "Regex": "(?i)^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$",
       "plural_name": false,

--- a/tests/test_regex_identifier.py
+++ b/tests/test_regex_identifier.py
@@ -2,6 +2,8 @@ import pytest
 
 from pywhat import regex_identifier
 
+def _assert_match_first_item(name, res):
+    assert name in res[0]["Regex Pattern"]["Name"]
 
 def test_regex_successfully_parses():
     r = regex_identifier.RegexIdentifier()
@@ -11,19 +13,19 @@ def test_regex_successfully_parses():
 def test_regex_runs():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["DANHz6EQVoWyZ9rER56DwTXHWUxfkv9k2o"])
-    assert "Dogecoin (DOGE) Wallet Address" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Dogecoin (DOGE) Wallet Address", res)
 
 
 def test_url():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["tryhackme.com"])
-    assert "Uniform Resource Locator (URL)" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Uniform Resource Locator (URL)", res)
 
 
 def test_url_2():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["http://username:password@example.com/"])
-    assert "Uniform Resource Locator (URL)" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Uniform Resource Locator (URL)", res)
 
 
 def test_invalid_tld():
@@ -35,50 +37,50 @@ def test_invalid_tld():
 def test_https():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["hTTPs://tryhackme.com"])
-    assert "Uniform Resource Locator (URL)" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Uniform Resource Locator (URL)", res)
 
 
 def test_lat_long():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["52.6169586, -1.9779857"])
-    assert "Latitude & Longitude Coordinates" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Latitude & Longitude Coordinates", res)
 
 
 def test_lat_long2():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["53.76297,-1.9388732"])
-    assert "Latitude & Longitude Coordinates" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Latitude & Longitude Coordinates", res)
 
 
 def test_lat_long3():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["77\u00B0 30' 29.9988\" N"])
-    assert "Latitude & Longitude Coordinates" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Latitude & Longitude Coordinates", res)
 
 
 def test_lat_long4():
     r = regex_identifier.RegexIdentifier()
     # degree symbol has to be a unicode character, otherwise Windows will not understand it
     res = r.check(["N 32\u00B0 53.733 W 096\u00B0 48.358"])
-    assert "Latitude & Longitude Coordinates" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Latitude & Longitude Coordinates", res)
 
 
 def test_lat_long5():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["41\u00B024'12.2\" N 2\u00B010'26.5\" E"])
-    assert "Latitude & Longitude Coordinates" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Latitude & Longitude Coordinates", res)
 
 
 def test_lat_long6():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["40.741895,-73.989308"])
-    assert "Latitude & Longitude Coordinates" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Latitude & Longitude Coordinates", res)
 
 
 def test_ip():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["http://10.1.1.1/just/a/test"])
-    assert "Uniform Resource Locator (URL)" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Uniform Resource Locator (URL)", res)
     assert "Internet Protocol (IP) Address Version 4" in res[1]["Regex Pattern"]["Name"]
 
 
@@ -97,7 +99,7 @@ def test_ip2():
 def test_ip3():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["2001:0db8:85a3:0000:0000:8a2e:0370:7334"])
-    assert "Internet Protocol (IP) Address Version 6" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Internet Protocol (IP) Address Version 6", res)
 
 
 def test_ip4():
@@ -112,37 +114,37 @@ def test_ip4():
 def test_international_url():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["http://папироска.рф"])
-    assert "Uniform Resource Locator (URL)" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Uniform Resource Locator (URL)", res)
 
 
 def test_same_international_url_in_punycode():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["https://xn--80aaxitdbjk.xn--p1ai/"])
-    assert "Uniform Resource Locator (URL)" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Uniform Resource Locator (URL)", res)
 
 
 def test_ctf_flag():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["thm{hello}"])
-    assert "TryHackMe Flag Format" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("TryHackMe Flag Format", res)
 
 
 def test_ctf_flag_uppercase():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["FLAG{hello}"])
-    assert "Capture The Flag (CTF) Flag" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Capture The Flag (CTF) Flag", res)
 
 
 def test_ethereum():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["0x52908400098527886E0F7030069857D2E4169EE7"])
-    assert "Ethereum (ETH) Wallet Address" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Ethereum (ETH) Wallet Address", res)
 
 
 def test_bitcoin():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY"])
-    assert "Bitcoin" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Bitcoin", res)
 
 
 def test_monero():
@@ -152,116 +154,116 @@ def test_monero():
             "47DF8D9NwtmefhFUghynYRMqrexiZTsm48T1hhi2jZcbfcwoPbkhMrrED6zqJRfeYpXFfdaqAT3jnBEwoMwCx6BYDJ1W3ub"
         ]
     )
-    assert "Monero (XMR) Wallet Address" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Monero (XMR) Wallet Address", res)
 
 
 def test_litecoin():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["LRX8rSPVjifTxoLeoJtLf2JYdJFTQFcE7m"])
-    assert "Litecoin (LTC) Wallet Address" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Litecoin (LTC) Wallet Address", res)
 
 
 def test_bitcoincash():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["bitcoincash:qzlg6uvceehgzgtz6phmvy8gtdqyt6vf359at4n3lq"])
-    assert "Bitcoin Cash (BCH) Wallet Address" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Bitcoin Cash (BCH) Wallet Address", res)
 
 
 def test_ripple():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["rBPAQmwMrt7FDDPNyjwFgwSqbWZPf6SLkk"])
-    assert "Ripple (XRP) Wallet Address" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Ripple (XRP) Wallet Address", res)
 
 
 def test_visa():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["4111111111111111"])
-    assert "Visa" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Visa", res)
 
 
 def test_visa_spaces():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["4607 0000 0000 0009"])
-    assert "Visa" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Visa", res)
 
 
 def test_master_Card():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["5500000000000004"])
-    assert "MasterCard" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("MasterCard", res)
 
 
 def test_master_card_spaces():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["5555 5555 5555 4444"])
-    assert "MasterCard" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("MasterCard", res)
 
 
 def test_american_express():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["340000000000009"])
-    assert "American Express" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("American Express", res)
 
 
 def test_american_express_spaces():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["3714 4963 5398 431"])
-    assert "American Express" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("American Express", res)
 
 
 def test_american_diners_club():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["30000000000004"])
-    assert "Diners Club Card" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Diners Club Card", res)
 
 
 def test_american_diners_club_spaces():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["3056 9309 0259 04"])
-    assert "Diners Club Card" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Diners Club Card", res)
 
 
 def test_discover_card():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["6011000000000004"])
-    assert "Discover" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Discover", res)
 
 
 def test_discover_card_spaces():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["6011 1111 1111 1117"])
-    assert "Discover" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Discover", res)
 
 
 def test_maestro_card():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["5038146401278870"])
-    assert "Maestro" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Maestro", res)
 
 
 def test_maestro_card_spaces():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["6759 6498 2643 8453"])
-    assert "Maestro" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Maestro", res)
 
 
 @pytest.mark.skip("Key:value is turned off")
 def test_username():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["james:S3cr37_P@$$W0rd"])
-    assert "Key:Value" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Key:Value", res)
 
 
 def test_email():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["github@skerritt.blog"])
-    assert "Email" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Email", res)
 
 
 def test_email2():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["firstname+lastname@example.com"])
-    assert "Email" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Email", res)
 
 
 def test_email3():
@@ -279,46 +281,46 @@ def test_email4():
 def test_phone_number():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["202-555-0178"])
-    assert "Phone Number" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Phone Number", res)
 
 
 def test_phone_number2():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["+1-202-555-0156"])
-    assert "Phone Number" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Phone Number", res)
     assert "United States" in res[0]["Regex Pattern"]["Description"]
 
 
 def test_phone_number3():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["+662025550156"])
-    assert "Phone Number" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Phone Number", res)
     assert "Thailand" in res[0]["Regex Pattern"]["Description"]
 
 
 def test_phone_number4():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["+356 202 555 0156"])
-    assert "Phone Number" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("Phone Number", res)
     assert "Malta" in res[0]["Regex Pattern"]["Description"]
 
 
 def test_youtube():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["https://www.youtube.com/watch?v=ScOAntcCa78"])
-    assert "YouTube" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("YouTube", res)
 
 
 def test_youtube2():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["http://www.youtube.com/watch?v=dQw4w9WgXcQ"])
-    assert "YouTube" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("YouTube", res)
 
 
 def test_youtube_id():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["dQw4w9WgXcQ"])
-    assert "YouTube" in res[0]["Regex Pattern"]["Name"]
+    _assert_match_first_item("YouTube", res)
 
 
 def test_youtube_id2():
@@ -416,3 +418,121 @@ def test_ssh_ed25519_key():
         ]
     )
     assert "SSH ED25519" in str(res)
+
+def test_google_api_key():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "AIzaSyD7CQl6fRhagGok6CzFGOOPne2X1u1spoA"
+        ]
+    )
+    _assert_match_first_item("Google API Key", res)
+
+def test_google_recaptcha_api_key():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "6Le3W6QUAAAANNT8X_9JwlNnK4kZGLaYTB3KqFLM"
+        ]
+    )
+    _assert_match_first_item("Google ReCaptcha API Key", res)
+
+
+def test_google_oauth_token():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "ya29.AHES6ZRnn6CfjjaK6GCQ84vikePv_hk4NUAJwzaAXamCL0s"
+        ]
+    )
+    _assert_match_first_item("Google OAuth Token", res)
+
+def test_aws_access_key_id():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "AKIA31OMZKYAARWZ3ERH"
+        ]
+    )
+    _assert_match_first_item("AWS Access Key ID", res)
+
+def test_mailgun_api_key():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "key-1e1631a9414aff7c262721e7b6ff6e43"
+        ]
+    )
+    _assert_match_first_item("Mailgun API Key", res)
+
+def test_twilio_api_key():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "SK012dab2d3f4dab1c2f33dffafdf23142"
+        ]
+    )
+    _assert_match_first_item("Twilio API Key", res)
+
+def test_twilio_account_sid():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "AC10a133ffdfb112abb2d3f42d1d2d3b14"
+        ]
+    )
+    _assert_match_first_item("Twilio Account SID", res)
+
+def test_twilio_application_sid():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "APfff01abd2b134a2aff3adc243ab211ab"
+        ]
+    )
+    _assert_match_first_item("Twilio Application SID", res)
+
+def test_square_application_secret():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "sq0csp-LBptIQ85io8CvbjVDvmzD1drQbOERgjlhnNrMgscFGk"
+        ]
+    )
+    _assert_match_first_item("Square Application Secret", res)
+
+def test_square_access_token():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "EAAAEBQZoq15Ub0PBBr_kw0zK-uIHcBPBZcfjPFT05ODfjng9GqFK9Dbgtj1ILcU"
+        ]
+    )
+    _assert_match_first_item("Square Access Token", res)
+
+def test_stripe_api_key():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "sk_live_vHDDrL02ioRF5vYtyqiYBKma"
+        ]
+    )
+    _assert_match_first_item("Stripe API Key", res)
+
+def test_github_access_token():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "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:test@github.com"
+        ]
+    )
+    _assert_match_first_item("GitHub Access Token", res)
+
+def test_slack_token():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(
+        [
+            "xoxb-51465443183-hgvhXVd2ISC2x7gaoRWBOUdQ"
+        ]
+    )
+    _assert_match_first_item("Slack Token", res)


### PR DESCRIPTION
This change adds checks for API keys from:
* Google
* AWS
* Mailgun
* Twilio
* Square
* Stripe
* GitHub
* Slack

The API keys in the tests have either been created by myself and then
invalidated or found on pastebin and confirmed to no longer be active.

Closes #42