### PR TITLE
Fix url for EUI-48 Identifier

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -463,7 +463,7 @@
       "plural_name": false,
       "Description": null,
       "Rarity": 0.5,
-      "URL": "https://maclookup.app/",
+      "URL": "https://maclookup.app/search/macs/",
       "Tags": [
          "Identifiers",
          "Networking"


### PR DESCRIPTION
The previous link for the "EUI -48 identifier" service returned 404.

I fixed the url.

From: https://maclookup.app
To: https://maclookup.app/search/macs/

Ex:
https://maclookup.app/search/macs/00:00:00:00:00:00