### PR TITLE
Add more 'Media' related regexes

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -151,7 +151,7 @@
    },
    {
       "Name": "Instagram Post",
-      "Regex": "^(https?:\\/\\/(?:(www\\.)?instagram\\.com\\/p\\/)([^/?#&]{1,15})(?:\\/)?)$",
+      "Regex": "^(https?:\\/\\/(?:(www\\.)?instagram\\.com(\\/[A-Za-z0-9_.]{1,30})?\\/p\\/)([a-zA-Z0-9_-]+)(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -163,7 +163,7 @@
    },
    {
       "Name": "Instagram User",
-      "Regex": "^(https?:\\/\\/(?:(www\\.)?instagram\\.com\\/)([^/?#&]{1,15})(?:\\/)?)$",
+      "Regex": "^(https?:\\/\\/(?:(www\\.)?instagram\\.com\\/)([A-Za-z0-9_.]{1,30})(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -175,7 +175,7 @@
    },
    {
       "Name": "Reddit Post",
-      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/[^\\/?#&]{1,15}\\/comments\\/([\\d\\w]+)(?:\\/)?)$",
+      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/([\\w]{2,21})\\/comments\\/(\\w{5,6})(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -187,7 +187,7 @@
    },
    {
       "Name": "Reddit User",
-      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/(?:user|u)\\/([^/?#&]{1,15})(?:\\/)?)$",
+      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/(?:user|u)\\/([\\w]{2,21})(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -199,7 +199,7 @@
    },
    {
       "Name": "Reddit Subreddit",
-      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/([^/?#&]{1,15})(?:\\/)?)$",
+      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/([\\w]{2,21})(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,

--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -114,7 +114,7 @@
    },
    {
       "Name": "YouTube Video",
-      "Regex": "^(https?:\\/\\/(?:youtu\\.be\\/|(?:[a-z]{2,3}\\.)?youtube\\.com\\/watch(?:\\?|#\\!)v=)([\\w-]{11}))$",
+      "Regex": "(?i)^(https?:\\/\\/(?:youtu\\.be\\/|(?:[a-z]{2,3}\\.)?youtube\\.com\\/watch(?:\\?|#\\!)v=)([\\w-]{11}))$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -127,7 +127,7 @@
    },
    {
       "Name": "Twitter Status",
-      "Regex": "^(https?:\\/\\/(?:twitter\\.com\\/)(?:#!\\/)?(\\w{1,15})\\/status(?:es)?\\/(\\d+))$",
+      "Regex": "(?i)^(https?:\\/\\/(?:(?:www\\.|mobile\\.)?twitter\\.com\\/)(?:#!\\/)?(\\w{1,15})\\/status(?:es)?\\/(\\d+))$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -139,7 +139,7 @@
    },
    {
       "Name": "Twitter User",
-      "Regex": "^(https?:\\/\\/(?:twitter\\.com\\/)(\\w{1,15})\\/?)$",
+      "Regex": "(?i)^(https?:\\/\\/(?:(?:www\\.|mobile\\.)?twitter\\.com\\/)(?:#!\\/)?(\\w{1,15})\\/?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -151,7 +151,7 @@
    },
    {
       "Name": "Instagram Post",
-      "Regex": "^(https?:\\/\\/(?:(www\\.)?instagram\\.com(\\/[A-Za-z0-9_.]{1,30})?\\/p\\/)([a-zA-Z0-9_-]+)(?:\\/)?)$",
+      "Regex": "(?i)^(https?:\\/\\/(?:(www\\.)?instagram\\.com(\\/[A-Za-z0-9_.]{1,30})?\\/p\\/)([a-zA-Z0-9_-]+)(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -163,7 +163,7 @@
    },
    {
       "Name": "Instagram User",
-      "Regex": "^(https?:\\/\\/(?:(www\\.)?instagram\\.com\\/)([A-Za-z0-9_.]{1,30})(?:\\/)?)$",
+      "Regex": "(?i)^(https?:\\/\\/(?:(www\\.)?instagram\\.com\\/)([A-Za-z0-9_.]{1,30})(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -175,7 +175,7 @@
    },
    {
       "Name": "Reddit Post",
-      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/([\\w]{2,21})\\/comments\\/(\\w{5,6})(?:\\/)?)$",
+      "Regex": "(?i)^(https?:\\/\\/((?:www\\.)?reddit\\.com\\/r\\/(\\w{2,21})\\/|(?!www)(\\w{2,21})\\.reddit\\.com\\/)comments\\/(\\w{5,6})(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -187,7 +187,7 @@
    },
    {
       "Name": "Reddit User",
-      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/(?:user|u)\\/([\\w]{2,21})(?:\\/)?)$",
+      "Regex": "(?i)^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/(?:user|u)\\/([\\w]{2,21})(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -199,7 +199,7 @@
    },
    {
       "Name": "Reddit Subreddit",
-      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/([\\w]{2,21})(?:\\/)?)$",
+      "Regex": "(?i)^(https?:\\/\\/((?:www\\.)?reddit\\.com\\/r\\/([\\w]{2,21})|(?:(?!www)([\\w]{2,21})\\.reddit\\.com))(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -211,7 +211,7 @@
    },
    {
       "Name": "Discord Invite",
-      "Regex": "^(https?:\\/\\/(?:(www\\.)?)(?:discord\\.gg\\/|discordapp\\.com\\/invite\\/|discord\\.com\\/invite\\/)([^\\/?#&]{1,15})(?:\\/)?)$",
+      "Regex": "(?i)^(https?:\\/\\/(?:(www\\.)?)(?:discord\\.gg\\/|discordapp\\.com\\/invite\\/|discord\\.com\\/invite\\/)([^\\/?#&]{1,15})(?:\\/)?)$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,

--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -126,6 +126,102 @@
       ]
    },
    {
+      "Name": "Twitter Status",
+      "Regex": "^(https?:\\/\\/(?:twitter\\.com\\/)(?:#!\\/)?(\\w{1,15})\\/status(?:es)?\\/(\\d+))$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "Media",
+         "Twitter"
+      ]
+   },
+   {
+      "Name": "Twitter User",
+      "Regex": "^(https?:\\/\\/(?:twitter\\.com\\/)(\\w{1,15})\\/?)$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "Media",
+         "Twitter"
+      ]
+   },
+   {
+      "Name": "Instagram Post",
+      "Regex": "^(https?:\\/\\/(?:(www\\.)?instagram\\.com\\/p\\/)([^/?#&]{1,15})(?:\\/)?)$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "Media",
+         "Instagram"
+      ]
+   },
+   {
+      "Name": "Instagram User",
+      "Regex": "^(https?:\\/\\/(?:(www\\.)?instagram\\.com\\/)([^/?#&]{1,15})(?:\\/)?)$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "Media",
+         "Instagram"
+      ]
+   },
+   {
+      "Name": "Reddit Post",
+      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/[^\\/?#&]{1,15}\\/comments\\/([\\d\\w]+)(?:\\/)?)$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "Media",
+         "Reddit"
+      ]
+   },
+   {
+      "Name": "Reddit User",
+      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/(?:user|u)\\/([^/?#&]{1,15})(?:\\/)?)$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "Media",
+         "Reddit"
+      ]
+   },
+   {
+      "Name": "Reddit Subreddit",
+      "Regex": "^(https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/([^/?#&]{1,15})(?:\\/)?)$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "Media",
+         "Reddit"
+      ]
+   },
+   {
+      "Name": "Discord Invite",
+      "Regex": "^(https?:\\/\\/(?:(www\\.)?)(?:discord\\.gg\\/|discordapp\\.com\\/invite\\/|discord\\.com\\/invite\\/)([^\\/?#&]{1,15})(?:\\/)?)$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "Media",
+         "Discord"
+      ]
+   },
+   {
       "Name": "Bitcoin Cash (BCH) Wallet Address",
       "Regex": "(?i)^(bitcoincash:[a-z0-9]{42})$",
       "plural_name": false,

--- a/tests/test_regex_identifier.py
+++ b/tests/test_regex_identifier.py
@@ -450,55 +450,55 @@ def test_youtube_channel_id():
 
 def test_twitter():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://twitter.com/jack/status/20"], boundaryless=Filter({"Tags": ["Media"]}))
+    res = r.check(["https://twitter.com/jack/status/20"])
     _assert_match_first_item("Twitter Status", res)
 
 
 def test_twitter_user():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://twitter.com/jack"], boundaryless=Filter({"Tags": ["Media"]}))
+    res = r.check(["https://twitter.com/jack"])
     _assert_match_first_item("Twitter User", res)
 
 
 def test_instagram():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://www.instagram.com/p/BHs_oZHU6VZ/"], boundaryless=Filter({"Tags": ["Media"]}))
+    res = r.check(["https://www.instagram.com/p/BHs_oZHU6VZ/"])
     _assert_match_first_item("Instagram Post", res)
 
 
 def test_instagram_user():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://www.instagram.com/instagram/"], boundaryless=Filter({"Tags": ["Media"]}))
+    res = r.check(["https://www.instagram.com/instagram/"])
     _assert_match_first_item("Instagram User", res)
 
 
 def test_reddit():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://www.reddit.com/r/funny/comments/3cxw9d/"], boundaryless=Filter({"Tags": ["Media"]}))
+    res = r.check(["https://www.reddit.com/r/funny/comments/3cxw9d/"])
     _assert_match_first_item("Reddit Post", res)
 
 
 def test_reddit_user():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://www.reddit.com/user/funny/"], boundaryless=Filter({"Tags": ["Media"]}))
+    res = r.check(["https://www.reddit.com/user/funny/"])
     _assert_match_first_item("Reddit User", res)
 
 
 def test_reddit_subreddit():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://www.reddit.com/r/funny/"], boundaryless=Filter({"Tags": ["Media"]}))
+    res = r.check(["https://www.reddit.com/r/funny/"])
     _assert_match_first_item("Reddit Subreddit", res)
 
 
 def test_discord_invite():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://discord.gg/vFxZxn"], boundaryless=Filter({"Tags": ["Media"]}))
+    res = r.check(["https://discord.gg/vFxZxn"])
     _assert_match_first_item("Discord Invite", res)
 
 
 def test_discord_invite2():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://discord.com/invite/vFxZxn"], boundaryless=Filter({"Tags": ["Media"]}))
+    res = r.check(["https://discord.com/invite/vFxZxn"])
     _assert_match_first_item("Discord Invite", res)
 
 

--- a/tests/test_regex_identifier.py
+++ b/tests/test_regex_identifier.py
@@ -448,6 +448,60 @@ def test_youtube_channel_id():
     _assert_match_first_item("YouTube Channel ID", res)
 
 
+def test_twitter():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://twitter.com/jack/status/20"], boundaryless=Filter({"Tags": ["Media"]}))
+    _assert_match_first_item("Twitter Status", res)
+
+
+def test_twitter_user():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://twitter.com/jack"], boundaryless=Filter({"Tags": ["Media"]}))
+    _assert_match_first_item("Twitter User", res)
+
+
+def test_instagram():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://www.instagram.com/p/BHs_oZHU6VZ/"], boundaryless=Filter({"Tags": ["Media"]}))
+    _assert_match_first_item("Instagram Post", res)
+
+
+def test_instagram_user():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://www.instagram.com/instagram/"], boundaryless=Filter({"Tags": ["Media"]}))
+    _assert_match_first_item("Instagram User", res)
+
+
+def test_reddit():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://www.reddit.com/r/funny/comments/3cxw9d/"], boundaryless=Filter({"Tags": ["Media"]}))
+    _assert_match_first_item("Reddit Post", res)
+
+
+def test_reddit_user():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://www.reddit.com/user/funny/"], boundaryless=Filter({"Tags": ["Media"]}))
+    _assert_match_first_item("Reddit User", res)
+
+
+def test_reddit_subreddit():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://www.reddit.com/r/funny/"], boundaryless=Filter({"Tags": ["Media"]}))
+    _assert_match_first_item("Reddit Subreddit", res)
+
+
+def test_discord_invite():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://discord.gg/vFxZxn"], boundaryless=Filter({"Tags": ["Media"]}))
+    _assert_match_first_item("Discord Invite", res)
+
+
+def test_discord_invite2():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://discord.com/invite/vFxZxn"], boundaryless=Filter({"Tags": ["Media"]}))
+    _assert_match_first_item("Discord Invite", res)
+
+
 def test_ssn():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["001-01-0001"])

--- a/tests/test_regex_identifier.py
+++ b/tests/test_regex_identifier.py
@@ -454,9 +454,27 @@ def test_twitter():
     _assert_match_first_item("Twitter Status", res)
 
 
+def test_twitter2():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["HTTPS://TWITTER.COM/#!/JACK/STATUS/20"])
+    _assert_match_first_item("Twitter Status", res)
+
+
+def test_twitter3():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://mobile.twitter.com/#!/JACK/status/20"])
+    _assert_match_first_item("Twitter Status", res)
+
+
 def test_twitter_user():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["https://twitter.com/jack"])
+    _assert_match_first_item("Twitter User", res)
+
+
+def test_twitter_user2():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["HTTPS://TWITTER.COM/#!/JACK"])
     _assert_match_first_item("Twitter User", res)
 
 
@@ -466,15 +484,39 @@ def test_instagram():
     _assert_match_first_item("Instagram Post", res)
 
 
+def test_instagram2():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["HTTPS://WWW.INSTAGRAM.COM/P/BHS_OZHU6VZ/"])
+    _assert_match_first_item("Instagram Post", res)
+
+
 def test_instagram_user():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://www.instagram.com/instagram/"])
+    res = r.check(["https://www.instagram.com/world_record_egg"])
+    _assert_match_first_item("Instagram User", res)
+
+
+def test_instagram_user2():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["HTTPS://INSTAGRAM.COM/WORLD_RECORD_EGG"])
     _assert_match_first_item("Instagram User", res)
 
 
 def test_reddit():
     r = regex_identifier.RegexIdentifier()
-    res = r.check(["https://www.reddit.com/r/funny/comments/3cxw9d/"])
+    res = r.check(["https://www.reddit.com/r/funny/comments/3cxw9d"])
+    _assert_match_first_item("Reddit Post", res)
+
+
+def test_reddit2():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["HTTPS://REDDIT.COM/R/FUNNY/COMMENTS/3CXW9D/"])
+    _assert_match_first_item("Reddit Post", res)
+
+
+def test_reddit3():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://funny.reddit.com/comments/3cxw9d"])
     _assert_match_first_item("Reddit Post", res)
 
 
@@ -484,9 +526,27 @@ def test_reddit_user():
     _assert_match_first_item("Reddit User", res)
 
 
+def test_reddit_user2():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["HTTPS://REDDIT.COM/USER/FUNNY/"])
+    _assert_match_first_item("Reddit User", res)
+
+
 def test_reddit_subreddit():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["https://www.reddit.com/r/funny/"])
+    _assert_match_first_item("Reddit Subreddit", res)
+
+
+def test_reddit_subreddit2():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["HTTPS://REDDIT.COM/R/FUNNY/"])
+    _assert_match_first_item("Reddit Subreddit", res)
+
+
+def test_reddit_subreddit3():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://funny.reddit.com/"])
     _assert_match_first_item("Reddit Subreddit", res)
 
 
@@ -500,6 +560,18 @@ def test_discord_invite2():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["https://discord.com/invite/vFxZxn"])
     _assert_match_first_item("Discord Invite", res)
+
+
+def test_discord_invite3():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["HTTPS://DISCORDAPP.COM/INVITE/VFXZXN/"])
+    _assert_match_first_item("Discord Invite", res)
+
+
+def test_discord_invite4():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["https://discord.com/vFxZxn"])
+    assert "Discord Invite" not in str(res)
 
 
 def test_ssn():


### PR DESCRIPTION
This adds media related regexes similar to the existing YouTube Video regex, in which they match the URL of something like a social media post.

Includes:
- Twitter Status
- Twitter User
- Instagram Post
- Instagram User
- Reddit Post
- Reddit User
- Reddit Subreddit
- Discord Invite

These will match URLs, so for example 'https://twitter.com/jack/status/20/', 'https://reddit.com/r/funny', 'https://discord.com/invite/hTKzmak', etc.