### PR TITLE
Added and removed some of the tags

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -7,8 +7,7 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "PGP",
-         "PGP public Key"
+         "PGP"
       ]
    },
    {
@@ -19,8 +18,7 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "PGP",
-         "PGP private Key"
+         "PGP"
       ]
    },
    {
@@ -32,7 +30,7 @@
       "URL": null,
       "Tags": [
          "Credentials",
-         "SSH RSA Public Key"
+         "SSH Public Key"
       ]
    },
    {
@@ -79,7 +77,7 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "CTF flag"
+         "CTF Flag"
       ]
    },
    {
@@ -90,7 +88,7 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "CTF flag"
+         "CTF Flag"
       ]
    },
    {
@@ -101,7 +99,7 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "CTF flag"
+         "CTF Flag"
       ]
    },
    {
@@ -214,8 +212,7 @@
       "Tags": [
          "Identifiers",
          "Networking",
-         "AWS",
-         "AWS ARN"
+         "AWS"
       ]
    },
    {
@@ -228,7 +225,6 @@
       "Tags": [
          "Identifiers",
          "Networking",
-         "IPv6",
          "IP"
       ]
    },
@@ -254,7 +250,6 @@
       "Tags": [
          "Identifiers",
          "Networking",
-         "IPv4",
          "IP"
       ]
    },
@@ -504,8 +499,7 @@
       "URL": null,
       "Tags": [
          "Credit Card",
-         "Finance",
-         "Maestro CC"
+         "Finance"
       ]
    },
    {
@@ -677,8 +671,7 @@
       "URL": null,
       "Tags": [
          "API Keys",
-         "Credentials",
-         "Mailgun"
+         "Credentials"
       ]
    },
    {
@@ -742,7 +735,7 @@
       "URL": "https://amzn.com/",
       "Tags": [
          "Identifiers",
-         "Amazon ASIN"
+         "Amazon"
       ]
    },
    {

--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -8,8 +8,7 @@
       "URL": null,
       "Tags": [
          "PGP",
-         "Pretty Good Privacy",
-         "Public Key"
+         "PGP public Key"
       ]
    },
    {
@@ -21,8 +20,7 @@
       "URL": null,
       "Tags": [
          "PGP",
-         "Pretty Good Privacy",
-         "Private Key"
+         "PGP private Key"
       ]
    },
    {
@@ -34,9 +32,7 @@
       "URL": null,
       "Tags": [
          "Credentials",
-         "Cyber Security",
-         "Public Key",
-         "RSA Public Key"
+         "SSH RSA Public Key"
       ]
    },
    {
@@ -48,8 +44,6 @@
       "URL": null,
       "Tags": [
          "Credentials",
-         "Cyber Security",
-         "Public Key",
          "SSH Public Key"
       ]
    },
@@ -62,8 +56,6 @@
       "URL": null,
       "Tags": [
          "Credentials",
-         "Cyber Security",
-         "Public Key",
          "SSH Public Key"
       ]
    },
@@ -87,7 +79,7 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "Cyber Security"
+         "CTF flag"
       ]
    },
    {
@@ -98,7 +90,7 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "Cyber Security"
+         "CTF flag"
       ]
    },
    {
@@ -109,7 +101,7 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "Cyber Security"
+         "CTF flag"
       ]
    },
    {
@@ -146,7 +138,6 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "Internet",
          "Networking",
          "AWS"
       ]
@@ -159,7 +150,6 @@
       "Rarity": 1,
       "URL": null,
       "Tags": [
-         "Internet",
          "Networking",
          "AWS"
       ]
@@ -174,7 +164,7 @@
       "Tags": [
          "API Keys",
          "Credentials",
-         "Square"
+         "Square API"
       ]
    },
    {
@@ -187,7 +177,7 @@
       "Tags": [
          "API Keys",
          "Credentials",
-         "Square"
+         "Square API"
       ]
    },
    {
@@ -238,7 +228,8 @@
       "Tags": [
          "Identifiers",
          "Networking",
-         "IPv6"
+         "IPv6",
+         "IP"
       ]
    },
    {
@@ -263,7 +254,8 @@
       "Tags": [
          "Identifiers",
          "Networking",
-         "IPv4"
+         "IPv4",
+         "IP"
       ]
    },
    {
@@ -274,7 +266,6 @@
       "Rarity": 0.7,
       "URL": "https://www.blockchain.com/btc/address/",
       "Tags": [
-         "Cryptocurrency",
          "Finance",
          "Cryptocurrency Wallet",
          "Bitcoin Wallet"
@@ -362,8 +353,6 @@
       "URL": null,
       "Tags": [
          "Credentials",
-         "Password",
-         "Username",
          "SSN"
       ]
    },
@@ -375,7 +364,8 @@
       "Rarity": 0.5,
       "URL": "https://www.youtube.com/channel/",
       "Tags": [
-         "Media"
+         "Media",
+         "YouTube"
       ]
    },
    {
@@ -386,7 +376,7 @@
       "Rarity": 0.5,
       "URL": null,
       "Tags": [
-          "Security",
+          "Credentials",
           "Token",
           "API Keys"
       ]
@@ -514,7 +504,8 @@
       "URL": null,
       "Tags": [
          "Credit Card",
-         "Finance"
+         "Finance",
+         "Maestro CC"
       ]
    },
    {
@@ -574,7 +565,8 @@
       "Rarity": 0.3,
       "URL": null,
       "Tags": [
-         "Credit Card"
+         "Credit Card",
+         "Finance"
       ]
    },
    {
@@ -685,7 +677,8 @@
       "URL": null,
       "Tags": [
          "API Keys",
-         "Credentials"
+         "Credentials",
+         "Mailgun"
       ]
    },
    {
@@ -749,7 +742,7 @@
       "URL": "https://amzn.com/",
       "Tags": [
          "Identifiers",
-         "Amazon"
+         "Amazon ASIN"
       ]
    },
    {
@@ -760,8 +753,6 @@
       "Rarity": 0.2,
       "URL": null,
       "Tags": [
-         "Security",
-         "Hacking",
          "Token",
          "Website",
          "JWT Token"
@@ -776,7 +767,7 @@
       "URL": null,
       "Tags": [
          "Credentials",
-         "Cyber Security",
+         "API Keys",
          "AWS"
        ]
     },
@@ -789,7 +780,7 @@
       "URL": null,
       "Tags": [
          "Credentials",
-         "Cyber Security",
+         "API Keys",
          "AWS"
        ]
     },
@@ -813,7 +804,8 @@
       "Rarity": 0.2,
       "URL": "https://www.youtube.com/watch?v=",
       "Tags": [
-         "Media"
+         "Media",
+         "YouTube Video"
       ]
    },
    {
@@ -824,7 +816,7 @@
       "Rarity": 0.2,
       "URL": null,
       "Tags": [
-         "Time"
+         "UNIX Timestamp"
       ]
    },
    {
@@ -835,7 +827,7 @@
       "Rarity": 0.2,
       "URL": null,
       "Tags": [
-         "Time"
+         "UNIX Timestamp"
       ]
    },
    {
@@ -846,7 +838,7 @@
       "Rarity": 0.2,
       "URL": null,
       "Tags": [
-         "Time"
+         "UNIX Timestamp"
       ]
    },
    {
@@ -857,7 +849,7 @@
       "Rarity": 0.2,
       "URL": null,
       "Tags": [
-         "Time"
+         "UNIX Timestamp"
       ]
    },
    {
@@ -868,9 +860,7 @@
       "Rarity": 0,
       "URL": null,
       "Tags": [
-         "Credentials",
-         "Password",
-         "Username"
+         "Credentials"
       ]
    }
 ]

--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -479,7 +479,7 @@ def test_only_text():
 def test_boundaryless():
     runner = CliRunner()
     result = runner.invoke(
-        main, ["-be", "identifiers, security", "abc118.103.238.230abc"]
+        main, ["-be", "identifiers, token", "abc118.103.238.230abc"]
     )
     assert result.exit_code == 0
     assert "Nothing found" in result.output

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -43,11 +43,11 @@ def test_identifier_works3():
 
 
 def test_identifier_filtration():
-    filter = {"Tags": ["Password"]}
+    filter = {"Tags": ["Credentials"]}
     r = identifier.Identifier(dist=Distribution(filter))
     regexes = r.identify("fixtures/file", only_text=False)["Regexes"]["file"]
     for regex in regexes:
-        assert "Password" in regex["Regex Pattern"]["Tags"]
+        assert "Credentials" in regex["Regex Pattern"]["Tags"]
 
 
 def test_identifier_filtration2():


### PR DESCRIPTION
I went through the list of available tags and here are some of the changes I made:
- removed ```Pretty Good Privacy``` as it is the same as ```PGP```
- removed ```Cryptocurrency``` as it was only used for Bitcoin and there is already ```Cryptocurrency wallet``` tag
- removed some of the more broad tags as they were used only on some regexes and I think there are better more specific tags
- renamed ```Time``` to ```UNIX Timestamp```
- added ```CTF flag``` tag, instead of having them under ```Cyber Security```
- added ```IP``` tag for both IPv4 and IPv6
- added ```Finance``` tag to Laser Card Number as it was missing