### PR TITLE
Make searching filenames for matches optional

### DIFF
--- a/pywhat/identifier.py
+++ b/pywhat/identifier.py
@@ -39,7 +39,7 @@ class Identifier:
         key: Optional[Callable] = None,
         reverse: Optional[bool] = None,
         boundaryless: Optional[Filter] = None,
-        search_filenames=False,
+        include_filenames=False,
     ) -> dict:
         if dist is None:
             dist = self.distribution
@@ -70,8 +70,7 @@ class Identifier:
                 magic_numbers = self._file_sig.open_binary_scan_magic_nums(string)
                 contents = self._file_sig.open_file_loc(string)
 
-                if search_filenames:
-                    # if -fn command option, add filename to the search
+                if include_filenames:
                     contents.append(os.path.basename(string))
 
                 regex = self._regex_id.check(contents, dist)

--- a/pywhat/identifier.py
+++ b/pywhat/identifier.py
@@ -38,7 +38,8 @@ class Identifier:
         dist: Distribution = None,
         key: Optional[Callable] = None,
         reverse: Optional[bool] = None,
-        boundaryless: Optional[Filter] = None
+        boundaryless: Optional[Filter] = None,
+        search_filenames=False,
     ) -> dict:
         if dist is None:
             dist = self.distribution
@@ -68,7 +69,11 @@ class Identifier:
 
                 magic_numbers = self._file_sig.open_binary_scan_magic_nums(string)
                 contents = self._file_sig.open_file_loc(string)
-                contents.append(os.path.basename(string))
+
+                if search_filenames:
+                    # if -fn command option, add filename to the search
+                    contents.append(os.path.basename(string))
+
                 regex = self._regex_id.check(contents, dist)
 
                 if not magic_numbers:

--- a/pywhat/what.py
+++ b/pywhat/what.py
@@ -90,11 +90,10 @@ def create_filter(rarity, include, exclude):
 )
 @click.option("--json", is_flag=True, help="Return results in json format.")
 @click.option(
-    "-fn",
-    "--search-filenames",
+    "-if",
+    "--include-filenames",
     is_flag=True,
-    help="Alongside of file contents also search filenames for any possible matches.",
-    default=False,
+    help="Search filenames for possible matches."
 )
 def main(**kwargs):
     """
@@ -211,7 +210,7 @@ def main(**kwargs):
         key,
         kwargs["reverse"],
         boundaryless,
-        kwargs["search_filenames"],
+        kwargs["include_filenames"],
     )
 
     p = printer.Printing()
@@ -234,7 +233,7 @@ class What_Object:
         key,
         reverse: bool,
         boundaryless: Filter,
-        search_filenames: bool,
+        include_filenames: bool,
     ) -> dict:
         """
         Returns a Python dictionary of everything that has been identified
@@ -245,7 +244,7 @@ class What_Object:
             key=key,
             reverse=reverse,
             boundaryless=boundaryless,
-            search_filenames=search_filenames
+            include_filenames=include_filenames
         )
 
 

--- a/pywhat/what.py
+++ b/pywhat/what.py
@@ -69,7 +69,7 @@ def create_filter(rarity, include, exclude):
     default="0.1:1",
 )
 @click.option("-i", "--include", help="Only show matches with these tags.")
-@click.option("-e", "--exclude", help="Disclude matches with these tags.")
+@click.option("-e", "--exclude", help="Exclude matches with these tags.")
 @click.option("-o", "--only-text", is_flag=True, help="Do not scan files or folders.")
 @click.option("-k", "--key", help="Sort by the specified key.")
 @click.option("--reverse", is_flag=True, help="Sort in reverse order.")
@@ -89,6 +89,13 @@ def create_filter(rarity, include, exclude):
     "-db", "--disable-boundaryless", is_flag=True, help="Disable boundaryless mode."
 )
 @click.option("--json", is_flag=True, help="Return results in json format.")
+@click.option(
+    "-fn",
+    "--search-filenames",
+    is_flag=True,
+    help="Alongside of file contents also search filenames for any possible matches.",
+    default=False,
+)
 def main(**kwargs):
     """
     pyWhat - Identify what something is.
@@ -199,7 +206,12 @@ def main(**kwargs):
             print("Invalid key")
             sys.exit(1)
     identified_output = what_obj.what_is_this(
-        kwargs["text_input"], kwargs["only_text"], key, kwargs["reverse"], boundaryless
+        kwargs["text_input"],
+        kwargs["only_text"],
+        key,
+        kwargs["reverse"],
+        boundaryless,
+        kwargs["search_filenames"],
     )
 
     p = printer.Printing()
@@ -216,7 +228,13 @@ class What_Object:
         self.id = identifier.Identifier(dist=distribution)
 
     def what_is_this(
-        self, text: str, only_text: bool, key, reverse: bool, boundaryless: Filter
+        self,
+        text: str,
+        only_text: bool,
+        key,
+        reverse: bool,
+        boundaryless: Filter,
+        search_filenames: bool,
     ) -> dict:
         """
         Returns a Python dictionary of everything that has been identified
@@ -227,6 +245,7 @@ class What_Object:
             key=key,
             reverse=reverse,
             boundaryless=boundaryless,
+            search_filenames=search_filenames
         )
 
 


### PR DESCRIPTION
Previously PyWhat always added the name of the file to the search. This PR makes it optional, so if someone wants PyWhat to also search filenames for any matches, they can now do it with `-if` command.