### PR TITLE
Better regex for BTC, BCH and XMR wallets

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -117,7 +117,7 @@
    },
    {
       "Name": "Bitcoin Cash (BCH) Wallet Address",
-      "Regex": "(?i)^(bitcoincash:[a-z0-9]{42})$",
+      "Regex": "(?i)^(((bitcoincash|bchreg|bchtest):)?(q|p)[a-z0-9]{41})$",
       "plural_name": false,
       "Description": null,
       "Rarity": 1,
@@ -255,7 +255,7 @@
    },
    {
       "Name": "Bitcoin (₿) Wallet Address",
-      "Regex": "^([13][a-km-zA-HJ-NP-Z1-9]{25,34})$",
+      "Regex": "^(([1][a-km-zA-HJ-NP-Z1-9]{25,35})|([3][a-km-zA-HJ-NP-Z1-9]{33})|(bc|tb)1(?!.*[1bio])[a-z0-9]{39,59})$",
       "plural_name": false,
       "Description": null,
       "Rarity": 0.7,
@@ -378,7 +378,7 @@
    },
    {
       "Name": "Monero (XMR) Wallet Address",
-      "Regex": "(?i)^(4(?:[0-9]|[A-B])[a-z0-9]{93})$",
+      "Regex": "(?i)^([48][0-9AB][1-9A-HJ-NP-Za-km-z]{93})$",
       "plural_name": false,
       "Description": null,
       "Rarity": 0.3,

--- a/tests/test_regex_identifier.py
+++ b/tests/test_regex_identifier.py
@@ -252,9 +252,21 @@ def test_ethereum():
     _assert_match_first_item("Ethereum (ETH) Wallet Address", res)
 
 
-def test_bitcoin():
+def test_bitcoin_p2pkh():
     r = regex_identifier.RegexIdentifier()
     res = r.check(["1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY"])
+    _assert_match_first_item("Bitcoin (₿) Wallet Address", res)
+
+
+def test_bitcoin_p2sh():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["3EmUH8Uh9EXE7axgyAeBsCc2vdUdKkDqWK"])
+    _assert_match_first_item("Bitcoin (₿) Wallet Address", res)
+
+
+def test_bitcoin_bech32():
+    r = regex_identifier.RegexIdentifier()
+    res = r.check(["bc1qj89046x7zv6pm4n00qgqp505nvljnfp6xfznyw"])
     _assert_match_first_item("Bitcoin (₿) Wallet Address", res)
 
 


### PR DESCRIPTION
- stricter BTC regex and support for newer BECH32 format (new tests for all three formats)
- stricter BCH and XMR regexes (Thank you Nick Carr!)