### PR TITLE
Automatically fill in the Curl webhook

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -650,7 +650,7 @@
       "Regex": "(?i)^(NRRA-[a-f0-9]{42})$",
       "plural_name": false,
       "Description": null,
-      "Exploit": "Use the command below to verify that the New Relic REST API Key is valid.\n  $ curl -X GET 'https://api.newrelic.com/v2/applications.json'      -H \"X-Api-Key:${APIKEY}\" -i\n\nIf valid, test furher to see if its an admin key[1]\n\n[1] https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/\n\nAPI Documentation: https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/",
+      "Exploit": "Use the command below to verify that the New Relic REST API Key is valid.\n  $ curl -X GET 'https://api.newrelic.com/v2/applications.json'      -H \"X-Api-Key:${API_KEY_HERE}\" -i\n\nIf valid, test furher to see if its an admin key[1]\n\n[1] https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/\n\nAPI Documentation: https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/",
       "Rarity": 1,
       "URL": null,
       "Tags": [
@@ -1330,7 +1330,7 @@
       "Regex": "^(key-[0-9a-zA-Z]{32})$",
       "plural_name": false,
       "Description": null,
-      "Exploit": "Use the command below to verify that private key is valid:\n  $ curl --user 'api:key-PRIVATEKEYHERE' \"https://api.mailgun.net/v3/domains\"\nAPI Documentation: https://documentation.mailgun.com/en/latest/api_reference.html",
+      "Exploit": "Use the command below to verify that private key is valid:\n  $ curl --user 'api:key-PRIVATE_KEY_HERE' \"https://api.mailgun.net/v3/domains\"\nAPI Documentation: https://documentation.mailgun.com/en/latest/api_reference.html",
       "Rarity": 0.3,
       "URL": null,
       "Tags": [

--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -148,7 +148,7 @@
       "Regex": "(?i)^(xox[p|b|o|a]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})$",
       "plural_name": false,
       "Description": null,
-      "Exploit": "Use the command below to verify that private key is valid:\n  $ curl -sX POST \"https://slack.com/api/auth.test?token=xoxp-TOKEN_HERE&pretty=1\"\n \nAPI Documentation: https://api.slack.com/web",
+      "Exploit": "Use the command below to verify that private key is valid:\n  $ curl -sX POST \"https://slack.com/api/auth.test?token=TOKEN_HERE&pretty=1\"\n \nAPI Documentation: https://api.slack.com/web",
       "Rarity": 1,
       "URL": null,
       "Tags": [
@@ -1275,7 +1275,7 @@
       "Regex": "^(xox[a-zA-Z]-[a-zA-Z0-9-]+)$",
       "plural_name": false,
       "Description": null,
-      "Exploit": "Use the command below to verify that private key is valid:\n  $ curl -sX POST \"https://slack.com/api/auth.test?token=xoxp-TOKEN_HERE&pretty=1\"\n \nAPI Documentation: https://api.slack.com/web",
+      "Exploit": "Use the command below to verify that private key is valid:\n  $ curl -sX POST \"https://slack.com/api/auth.test?token=TOKEN_HERE&pretty=1\"\n \nAPI Documentation: https://api.slack.com/web",
       "Rarity": 0.3,
       "URL": null,
       "Tags": [

--- a/pywhat/regex_identifier.py
+++ b/pywhat/regex_identifier.py
@@ -31,6 +31,10 @@ class RegexIdentifier:
                     reg = copy.copy(reg)
                     matched = self.clean_text(matched_regex.group(0))
 
+                    if reg.get("Exploit") is not None and "curl" in reg["Exploit"]:
+                        # Replace anything like XXXXX_XXXXXX_HERE with the match
+                        reg["Exploit"] = re.sub(r'[A-Z_]+_HERE', matched, reg["Exploit"])
+
                     children = reg.get("Children")
                     if children is not None:
                         processed_match = re.sub(

--- a/tests/test_regex_identifier.py
+++ b/tests/test_regex_identifier.py
@@ -661,10 +661,16 @@ def test_github_access_token():
     _assert_match_first_item("GitHub Access Token", res)
 
 
+def test_slack_api_key():
+    res = r.check(["xoxp-514654431830-843187921057-792480346180-d44d2r9b71f954o8z2k5llt41ovpip6v"])
+    _assert_match_first_item("Slack API Key", res)
+    _assert_match_exploit_first_item("https://slack.com/api/auth.test?token=xoxp-514654431830-843187921057-792480346180-d44d2r9b71f954o8z2k5llt41ovpip6v", res)
+
+
 def test_slack_token():
     res = r.check(["xoxb-51465443183-hgvhXVd2ISC2x7gaoRWBOUdQ"])
     _assert_match_first_item("Slack Token", res)
-    _assert_match_exploit_first_item("https://slack.com/api/auth.test?token=xoxp-xoxb-51465443183-hgvhXVd2ISC2x7gaoRWBOUdQ", res)
+    _assert_match_exploit_first_item("https://slack.com/api/auth.test?token=xoxb-51465443183-hgvhXVd2ISC2x7gaoRWBOUdQ", res)
 
 
 def test_pgp_public_key():

--- a/tests/test_regex_identifier.py
+++ b/tests/test_regex_identifier.py
@@ -14,6 +14,10 @@ def _assert_match_first_item(name, res):
     assert name in res[0]["Regex Pattern"]["Name"]
 
 
+def _assert_match_exploit_first_item(search, res):
+    assert search in res[0]["Regex Pattern"]["Exploit"]
+
+
 def test_regex_successfully_parses():
     assert "Name" in r.distribution.get_regexes()[0]
 
@@ -660,6 +664,7 @@ def test_github_access_token():
 def test_slack_token():
     res = r.check(["xoxb-51465443183-hgvhXVd2ISC2x7gaoRWBOUdQ"])
     _assert_match_first_item("Slack Token", res)
+    _assert_match_exploit_first_item("https://slack.com/api/auth.test?token=xoxp-xoxb-51465443183-hgvhXVd2ISC2x7gaoRWBOUdQ", res)
 
 
 def test_pgp_public_key():


### PR DESCRIPTION
Implements #152

Not the prettiest solution but it seems to work fine, so long as the exploit uses a placeholder that's in all-caps and ends with `_HERE`.