### PR TITLE
Fix exploit token replacement when having multiple matches

### DIFF
--- a/pywhat/regex_identifier.py
+++ b/pywhat/regex_identifier.py
@@ -31,7 +31,10 @@ class RegexIdentifier:
                     reg_match = copy.deepcopy(reg)
                     matched = self.clean_text(matched_regex.group(0))
 
-                    if reg_match.get("Exploit") is not None and "curl" in reg_match["Exploit"]:
+                    if (
+                        reg_match.get("Exploit") is not None
+                        and "curl" in reg_match["Exploit"]
+                    ):
                         # Replace anything like XXXXX_XXXXXX_HERE with the match
                         reg_match["Exploit"] = re.sub(
                             r"[A-Z_]+_HERE", matched, reg_match["Exploit"]
@@ -65,9 +68,9 @@ class RegexIdentifier:
                                     matched_children.append(children["Items"][element])
 
                         if matched_children:
-                            reg_match["Description"] = children.get("entry", "") + ", ".join(
-                                matched_children
-                            )
+                            reg_match["Description"] = children.get(
+                                "entry", ""
+                            ) + ", ".join(matched_children)
                     reg_match.pop("Children", None)
 
                     matches.append(

--- a/pywhat/regex_identifier.py
+++ b/pywhat/regex_identifier.py
@@ -28,16 +28,16 @@ class RegexIdentifier:
                     reg["Boundaryless Regex"] if reg in boundaryless else reg["Regex"]
                 )
                 for matched_regex in re.finditer(regex, string, re.MULTILINE):
-                    reg = copy.copy(reg)
+                    reg_match = copy.deepcopy(reg)
                     matched = self.clean_text(matched_regex.group(0))
 
-                    if reg.get("Exploit") is not None and "curl" in reg["Exploit"]:
+                    if reg_match.get("Exploit") is not None and "curl" in reg_match["Exploit"]:
                         # Replace anything like XXXXX_XXXXXX_HERE with the match
-                        reg["Exploit"] = re.sub(
-                            r"[A-Z_]+_HERE", matched, reg["Exploit"]
+                        reg_match["Exploit"] = re.sub(
+                            r"[A-Z_]+_HERE", matched, reg_match["Exploit"]
                         )
 
-                    children = reg.get("Children")
+                    children = reg_match.get("Children")
                     if children is not None:
                         processed_match = re.sub(
                             children.get("deletion_pattern", ""), "", matched
@@ -65,15 +65,15 @@ class RegexIdentifier:
                                     matched_children.append(children["Items"][element])
 
                         if matched_children:
-                            reg["Description"] = children.get("entry", "") + ", ".join(
+                            reg_match["Description"] = children.get("entry", "") + ", ".join(
                                 matched_children
                             )
-                    reg.pop("Children", None)
+                    reg_match.pop("Children", None)
 
                     matches.append(
                         {
                             "Matched": matched,
-                            "Regex Pattern": reg,
+                            "Regex Pattern": reg_match,
                         }
                     )
 


### PR DESCRIPTION
While testing my changes on !162, I noticed that there was a problem in the _Exploit_ reporting when there were multiple matches in the file:
```
➜  pyWhat git:(fix_here_replacement) pywhat fixtures/file | grep -A 2 -B 1 'Twilio Account SID'
Matched on: ACAQDrnjkGtf3iA46rtwsvRiscvMTCw30l
Name: Twilio Account SID
Exploit: Use the command below to verify that the SID is valid:
  $ curl -X GET 'https://api.twilio.com/2010-04-01/Accounts.json' -u ACAQDrnjkGtf3iA46rtwsvRiscvMTCw30l:[AUTH_TOKEN]
--
--
Matched on: ACAWIQTrhbtfozp14V6UTmPyMVUMT0fjjg
Name: Twilio Account SID
Exploit: Use the command below to verify that the SID is valid:
  $ curl -X GET 'https://api.twilio.com/2010-04-01/Accounts.json' -u ACAQDrnjkGtf3iA46rtwsvRiscvMTCw30l:[AUTH_TOKEN]
--
--
Matched on: ACgkQ8jFVDE9H447pKwD6A5xwUqIDprBzr
Name: Twilio Account SID
Exploit: Use the command below to verify that the SID is valid:
  $ curl -X GET 'https://api.twilio.com/2010-04-01/Accounts.json' -u ACAQDrnjkGtf3iA46rtwsvRiscvMTCw30l:[AUTH_TOKEN]
```

Looking at the code, I found the issue was caused by https://github.com/bee-san/pyWhat/blob/main/pywhat/regex_identifier.py#L31 where a _shallow_ copy was used and the regex match reference was directly manipulated due to the same name. I have change the copy to _deep_ and rename the matched expression data.

After fixing the issue, each token is replaced correspondingly:
```
➜  pyWhat git:(fix_here_replacement) pywhat fixtures/file | grep -A 2 -B 1 'Twilio Account SID'
Matched on: ACAQDrnjkGtf3iA46rtwsvRiscvMTCw30l
Name: Twilio Account SID
Exploit: Use the command below to verify that the SID is valid:
  $ curl -X GET 'https://api.twilio.com/2010-04-01/Accounts.json' -u ACAQDrnjkGtf3iA46rtwsvRiscvMTCw30l:[AUTH_TOKEN]
--
--
Matched on: ACAWIQTrhbtfozp14V6UTmPyMVUMT0fjjg
Name: Twilio Account SID
Exploit: Use the command below to verify that the SID is valid:
  $ curl -X GET 'https://api.twilio.com/2010-04-01/Accounts.json' -u ACAWIQTrhbtfozp14V6UTmPyMVUMT0fjjg:[AUTH_TOKEN]
--
--
Matched on: ACgkQ8jFVDE9H447pKwD6A5xwUqIDprBzr
Name: Twilio Account SID
Exploit: Use the command below to verify that the SID is valid:
  $ curl -X GET 'https://api.twilio.com/2010-04-01/Accounts.json' -u ACgkQ8jFVDE9H447pKwD6A5xwUqIDprBzr:[AUTH_TOKEN]
```