### PR TITLE
Fix nox tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,6 @@ def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> Non
     session.install("--constraint=requirements.txt", *args, **kwargs)
 
 
-@nox.session(python="3.8")
 def black(session: Session) -> None:
     """Run black code formatter."""
     args = session.posargs or locations
@@ -42,12 +41,10 @@ def black(session: Session) -> None:
     session.run("black", *args)
 
 
-@nox.session(python=["3.8", "3.7"])
 def lint(session: Session) -> None:
     pass
 
 
-@nox.session(python=["3.8", "3.7"])
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.run("poetry", "install", "--no-dev", external=True)
@@ -55,7 +52,6 @@ def tests(session: Session) -> None:
     session.run("pytest")
 
 
-@nox.session(python=["3.8", "3.7"])
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     args = session.posargs or ["-m", "not e2e"]
@@ -66,7 +62,6 @@ def typeguard(session: Session) -> None:
     session.run("pytest", f"--typeguard-packages={package}", *args)
 
 
-@nox.session(python="3.8")
 def coverage(session: Session) -> None:
     """Upload coverage data."""
     install_with_constraints(session, "coverage[toml]", "codecov")


### PR DESCRIPTION
Fixes nox file to not be restricted to only using Python 3.8 and Python 3.7. This fixes the Python 3.6 and Python 3.9 CI checks.