### PR TITLE
leverage falseness of empty dicts

### DIFF
--- a/pywhat/identifier.py
+++ b/pywhat/identifier.py
@@ -90,7 +90,7 @@ class Identifier:
 
         for key_, value in identify_obj.items():
             # if there are zero regex or file signature matches, set it to None
-            if len(identify_obj[key_]) == 0:
+            if not value:
                 identify_obj[key_] = None
 
         if key != Keys.NONE:


### PR DESCRIPTION
just a tiny performance improvement, no need to retrieve the value via the `key_` again and check the length explicitly.