### PR TITLE
Add datadog client token

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -686,16 +686,31 @@
       ]
    },
    {
+      "Name": "Datadog API Key",
+      "Regex": "^([a-f0-9]{32})$",
+      "plural_name": false,
+      "Description": null,
+      "Exploit": "Use the command below to verify that the API key is valid:\n  $ curl -X GET https://api.datadoghq.com/api/v1/validate -H \"Content-Type: application/json\" -H \"DD-API-KEY: API_KEY_HERE\"\n",
+      "Rarity": 1,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Bug Bounty",
+         "Credentials",
+         "Datadog"
+      ]
+   },
+   {
       "Name": "Datadog Client Token",
       "Regex": "^(pub[a-f0-9]{32})$",
       "plural_name": false,
-      "Description": "Client tokens are used to send events and logs from web and mobile applications.",
+      "Description": null,
       "Exploit": null,
       "Rarity": 1,
       "URL": null,
       "Tags": [
          "API Keys",
-         "Credentials",
+         "Bug Bounty",
          "Datadog"
       ]
    },

--- a/tests/test_regex_identifier.py
+++ b/tests/test_regex_identifier.py
@@ -906,6 +906,11 @@ def test_zapier_webhook():
     _assert_match_first_item("Zapier Webhook Token", res)
 
 
+def test_datadog_api_key():
+    res = r.check(["acb6d73d95a10d30aef9894603e90963"])
+    _assert_match_first_item("Datadog API Key", res)
+
+
 def test_datadog_client_token():
     res = r.check(["pub85abf45b82e2f86f25003d559bca07d9"])
     _assert_match_first_item("Datadog Client Token", res)


### PR DESCRIPTION
**⚠ Pull Requests not made with this template will be automatically closed 🔥**

# Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

# Why do we need this pull request?
* With the client token you can send events and logs pf a web and mobile application to Datadog.

# What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
* no issue realted to it

# Copy / paste of output

Please copy and paste the output of PyWhat with your new addition using an example that tests this addition below:

```console
$ poetry run pywhat pub85abf45b82e2f86f25003d559bca07d9
Matched on: pub85abf45b82e2f86f25003d559bca07d9
Name: Datadog Client Token
Description: Client tokens are used to send events and logs from web and mobile applications.

Matched on: b85abf45b82e2f86f25003d5
Name: ObjectID

```
