### PR TITLE
New Mailchimp keys

### DIFF
--- a/fixtures/file
+++ b/fixtures/file
@@ -101,3 +101,5 @@ https://hooks.slack.com/services/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
 
 doi:10.1392/BC1.0
 10.1000/123
+
+a80122b2565c3e26a61cbf58d1d1aad7-us5

--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -1330,7 +1330,7 @@
       "Regex": "(?i)^([0-9a-f]{32}-us[0-9]{1,2})$",
       "plural_name": false,
       "Description": null,
-      "Exploit": "Use the command below to verify that the API key is valid:\n  $ curl --request GET --url 'https://<dc>.api.mailchimp.com/3.0/' --user 'anystring:API_KEY_HERE' --include\n",
+      "Exploit": "Use the command below to verify that the API key is valid (substitute <dc> for your datacenter, i. e. us5):\n  $ curl --request GET --url 'https://<dc>.api.mailchimp.com/3.0/' --user 'anystring:API_KEY_HERE' --include\n",
       "Rarity": 0.8,
       "URL": null,
       "Tags": [
@@ -1338,7 +1338,15 @@
          "API Keys",
          "Credentials",
          "Mailchimp"
-      ]
+      ],
+      "Examples": {
+         "Valid": [
+            "d619ce3b691e29ec064fede7ff9afbff-us5",
+            "4bf6010e49fb0791f3940681791934e7-us5",
+            "a80122b2565c3e26a61cbf58d1d1aad7-us5"
+         ],
+         "Invalid": []
+      }
    },
    {
       "Name": "Notion Integration Token",

--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -357,6 +357,13 @@ def test_file_fixture_doi():
     assert re.findall("DOI", str(result.output))
 
 
+def test_file_fixture_mailchimp():
+    runner = CliRunner()
+    result = runner.invoke(main, ["-db", "fixtures/file"])
+    assert result.exit_code == 0
+    assert re.findall("Mailchimp", str(result.output))
+
+
 def test_file_cors():
     runner = CliRunner()
     result = runner.invoke(main, ["-db", "Access-Control-Allow: *"])


### PR DESCRIPTION
**⚠ Pull Requests not made with this template will be automatically closed 🔥**

# Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

# What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
* This adds some example tokens to the mailchimp API keys mentioned in #150 
* Unfortunately, the URL to check that the API key is valid depends partly on the datacenter the key itself is assigned to. This means that if the key ends with us-5, for example, the requested url is `https://us5.api.mailchimp.com/3.0/`. Maybe that would be a useful feature to add to the exploit key to support multiple capture groups. I've added a comment to the Mailchimp exploit string (see the output below) but there might be other examples where this could be a useful feature.

# Copy / paste of output
```console
> what a80122b2565c3e26a61cbf58d1d1aad7-us5
Matched on: a80122b2565c3e26a61cbf58d1d1aad7
Name: Datadog API Key
Exploit: Use the command below to verify that the API key is valid:
  $ curl -X GET https://api.datadoghq.com/api/v1/validate -H "Content-Type: application/json" -H "DD-API-KEY: 
a80122b2565c3e26a61cbf58d1d1aad7"


Matched on: a80122b2565c3e26a61cbf58d1d1aad7-us5
Name: Mailchimp API Key
Exploit: Use the command below to verify that the API key is valid (substitute <dc> for your datacenter, i. e. us5):
  $ curl --request GET --url 'https://<dc>.api.mailchimp.com/3.0/' --user 
'anystring:a80122b2565c3e26a61cbf58d1d1aad7-us5' --include


Matched on: 122b2565c3e26a61cbf58d1d1aad7
Name: Bitcoin (₿) Wallet Address
Link:  https://www.blockchain.com/btc/address/122b2565c3e26a61cbf58d1d1aad7

Matched on: e26
Name: Latitude & Longitude Coordinates
Link:  https://www.google.com/maps/place/e26
```