### PR TITLE
added SHA-1 hashing algorithm detection regex

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -130,6 +130,17 @@
       }
    },
    {
+      "Name": "SHA-1 hash format",
+      "Regex": "\b[0-9a-fA-F]{40}\b",
+      "plural_name": false,
+      "Description": "SHA-1 algoritm, used to check integrability of a file.",
+      "Rarity": 1,
+      "URL": "https://en.wikipedia.org/wiki/SHA-1",
+      "Tags": [
+         "Hash"
+      ]
+   },
+   {
       "Name": "TryHackMe Flag Format",
       "Regex": "(?i)^(thm{.*}|tryhackme{.*})$",
       "plural_name": false,


### PR DESCRIPTION
added SHA-1 hashing algorithm detection regex, a really usefull feature

**⚠ Pull Requests not made with this template will be automatically closed 🔥**

# Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

# Why do we need this pull request?
* Explain the _why_ behind your PR. We can see what it does from the code. But _why_ does it do that?

> This is a common algorithm that is currently undetected by this application

# What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
* Fixes #10000

# Copy / paste of output

Please copy and paste the output of PyWhat with your new addition using an example that tests this addition below:

```console
> what "A14D3682C92974987D0CB5B1CC61D2D098D9CD51"

Matched on: A14D3682C92974987D0CB5B1CC61D2D098D9CD51
Name: SHA-1 hash format
Description: SHA-1 algoritm, used to check integrability of a file.
```
