### PR TITLE
Fixed #231 Datadog API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ orjson = {version = "^3.6.1", optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
-black = {version = "^21.9b0", python = "^3.6.2"} 
+black = {version = "^21.9b0", python = "^3.6.2"}
 isort = {version = "^5.9.3", python = "^3.6.1"}
 flake8 = "<4.0"
 requests = "^2.26.0"

--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -2346,6 +2346,26 @@
       }
    },
    {
+      "Name": "Datadog Client Token",
+      "Regex": "^(pub[a-f0-9]{32})$",
+      "plural_name": false,
+      "Description": null,
+      "Exploit": null,
+      "Rarity": 0.3,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Bug Bounty",
+         "Datadog"
+      ],
+      "Examples": {
+         "Valid": [
+            "pub8261e4a07b29d0a148e00a93106ae711"
+         ],
+         "Invalid": []
+      }
+   },
+   {
       "Name": "JSON Web Token (JWT)",
       "Regex": "(?i)^((?=.*[a-z])(?=.*[0-9])(?:[a-z0-9_=]+\\.){2}(?:[a-z0-9_\\-\\+\\/=]*))$",
       "plural_name": false,
@@ -2467,26 +2487,6 @@
          "Valid": [
             "EAARE0ZATePjUBAFxfm2L2aWdtNXOSscOnMYktEPYJuOSrteSQZCh9VWVVKnhSSYNumEnju6XItaRhija3pA7LFPHquTbi4IDZC8k9EMByeQ4NJzCFsc40FMIQIgvnCTOK5qt6xBZCUMf7S95X6nnqCUVw2iS0DRDbqttxauxIDgBRYJ7zZABXe9V0CY872DUl3BfyINIYfCXmRZC8loACc",
             "EAARE0ZATePjUBAHVHoVVbRc9N0u2lNC5eJab59qwD9mG5ZCRgcg3qlbPZC07EkP65Ji3BnPzPKZBMqN7WyOfJ8Riky4RD66aSqX8U0d14EWwHx94rZCtM6qfULiXOrqWKiG2KLyJJnRzAus3ubodKUwTuZCBcPmcGJcvq5Krfk8xgLQVZBoFLGLJs5wT4SlBxiWAdytlggqzQZDZD"
-         ],
-         "Invalid": []
-      }
-   },
-   {
-      "Name": "Datadog Client Token",
-      "Regex": "^(pub[a-f0-9]{32})$",
-      "plural_name": false,
-      "Description": "An [#CAE4F1][link=https://docs.datadoghq.com/logs/log_collection/javascript/]Datadog client token[/link][/#CAE4F1]",
-      "Exploit": null,
-      "Rarity": 0.2,
-      "URL": null,
-      "Tags": [
-         "API Keys",
-         "Bug Bounty",
-         "Datadog"
-      ],
-      "Examples": {
-         "Valid": [
-            "pub8261e4a07b29d0a148e00a93106ae711"
          ],
          "Invalid": []
       }
@@ -2616,7 +2616,7 @@
       "Name": "Datadog API Key",
       "Regex": "^([a-f0-9]{32})$",
       "plural_name": false,
-      "Description": "An [#CAE4F1][link=https://docs.datadoghq.com/api/latest/]Datadog API Key[/link][/#CAE4F1]",
+      "Description": null,
       "Exploit": "Use the command below to verify that the API key is valid:\n  $ curl -X GET https://api.datadoghq.com/api/v1/validate -H \"Content-Type: application/json\" -H \"DD-API-KEY: API_KEY_HERE\"\n",
       "Rarity": 0,
       "URL": null,
@@ -2642,7 +2642,7 @@
       "Name": "Datadog Application Key",
       "Regex": "^([a-f0-9]{40})$",
       "plural_name": false,
-      "Description": "An [#CAE4F1][link=https://docs.datadoghq.com/api/latest/]Datadog Application Key[/link][/#CAE4F1]",
+      "Description": null,
       "Exploit": null,
       "Rarity": 0,
       "URL": null,

--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -820,35 +820,6 @@
       }
    },
    {
-      "Name": "Datadog API Key",
-      "Regex": "^([a-f0-9]{32})$",
-      "plural_name": false,
-      "Description": null,
-      "Exploit": "Use the command below to verify that the API key is valid:\n  $ curl -X GET https://api.datadoghq.com/api/v1/validate -H \"Content-Type: application/json\" -H \"DD-API-KEY: API_KEY_HERE\"\n",
-      "Rarity": 1,
-      "URL": null,
-      "Tags": [
-         "API Keys",
-         "Bug Bounty",
-         "Credentials",
-         "Datadog"
-      ]
-   },
-   {
-      "Name": "Datadog Client Token",
-      "Regex": "^(pub[a-f0-9]{32})$",
-      "plural_name": false,
-      "Description": null,
-      "Exploit": null,
-      "Rarity": 1,
-      "URL": null,
-      "Tags": [
-         "API Keys",
-         "Bug Bounty",
-         "Datadog"
-      ]
-   },
-   {
       "Name": "New Relic Admin API Key",
       "Regex": "(?i)^(NRAA-[a-f0-9]{27})$",
       "plural_name": false,
@@ -2501,6 +2472,26 @@
       }
    },
    {
+      "Name": "Datadog Client Token",
+      "Regex": "^(pub[a-f0-9]{32})$",
+      "plural_name": false,
+      "Description": "An [#CAE4F1][link=https://docs.datadoghq.com/logs/log_collection/javascript/]Datadog client token[/link][/#CAE4F1]",
+      "Exploit": null,
+      "Rarity": 0.2,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Bug Bounty",
+         "Datadog"
+      ],
+      "Examples": {
+         "Valid": [
+            "pub8261e4a07b29d0a148e00a93106ae711"
+         ],
+         "Invalid": []
+      }
+   },
+   {
       "Name": "ObjectID",
       "Regex": "^([0-9a-fA-F]{24})$",
       "plural_name": false,
@@ -2619,6 +2610,58 @@
             "01ERJ58HMWDN3VTRRHZQV2T5R5"
          ],
          "Invalid": []
+      }
+   },
+   {
+      "Name": "Datadog API Key",
+      "Regex": "^([a-f0-9]{32})$",
+      "plural_name": false,
+      "Description": "An [#CAE4F1][link=https://docs.datadoghq.com/api/latest/]Datadog API Key[/link][/#CAE4F1]",
+      "Exploit": "Use the command below to verify that the API key is valid:\n  $ curl -X GET https://api.datadoghq.com/api/v1/validate -H \"Content-Type: application/json\" -H \"DD-API-KEY: API_KEY_HERE\"\n",
+      "Rarity": 0,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Bug Bounty",
+         "Credentials",
+         "Datadog"
+      ],
+      "Examples": {
+         "Valid": [
+            "68ec0cbd7d0da6770545614dfa573eec",
+            "683bba7d7f759e0907d35f39a7c36eb5",
+            "c8561e9b786a07855cbc2983d47eaf93"
+         ],
+         "Invalid": [
+            "ba36266055c7495ce26bb12e86c7536b4a5e00cd",
+            "pub8261e4a07b29d0a148e00a93106ae711"
+         ]
+      }
+   },
+   {
+      "Name": "Datadog Application Key",
+      "Regex": "^([a-f0-9]{40})$",
+      "plural_name": false,
+      "Description": "An [#CAE4F1][link=https://docs.datadoghq.com/api/latest/]Datadog Application Key[/link][/#CAE4F1]",
+      "Exploit": null,
+      "Rarity": 0,
+      "URL": null,
+      "Tags": [
+         "API Keys",
+         "Bug Bounty",
+         "Credentials",
+         "Datadog"
+      ],
+      "Examples": {
+         "Valid": [
+            "ba36266055c7495ce26bb12e86c7536b4a5e00cd"
+         ],
+         "Invalid": [
+            "68ec0cbd7d0da6770545614dfa573eec",
+            "683bba7d7f759e0907d35f39a7c36eb5",
+            "c8561e9b786a07855cbc2983d47eaf93",
+            "pub8261e4a07b29d0a148e00a93106ae711"
+         ]
       }
    },
    {


### PR DESCRIPTION


## Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

## Why do we need this pull request?
* The old rarity of Datadog regexp was too high

## What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
- reduced rarity to 0
- add Datalog Application API and Datadog Client key
- add valid and invalid examples
- remove a junk space in `pyproject.toml`

## Copy / paste of output
### API Key
```console
shell:~$ poetry run what -r 0:1 68ec0cbd7d0da6770545614dfa573eec
Matched on: 6770545614
Name: Phone Number

Matched on: 677054561
Name: American Social Security Number
Description: An American Identification Number

Matched on: 68ec0cbd7d0da6770545614dfa573eec
Name: Datadog API Key
Description: An Datadog API Key
Exploit: Use the command below to verify that the API key is valid:
  $ curl -X GET https://api.datadoghq.com/api/v1/validate -H "Content-Type: application/json" -H "DD-API-KEY:
68ec0cbd7d0da6770545614dfa573eec"
```

### Application Key
```console
shell:~$ poetry run what -r 0:1 ba36266055c7495ce26bb12e86c7536b4a5e00cd
Matched on: ba36266055c7495ce26bb12e86c7536b4a5e00cd
Name: Bitly Secret Key
Exploit: Use the command below to verify that the secret key is valid:
  $ curl "https://api-ssl.bitly.com/v3/shorten?access_token=ba36266055c7495ce26bb12e86c7536b4a5e00cd&longUrl=https://www
.google.com"


Matched on: ba36266055c7495ce26bb12e86c7536b4a5e00cd
Name: Visual Studio App Center API Token

Matched on: ba36266055c7495ce26bb12e86c7536b4a5e00cd
Name: Amazon Web Services Secret Access Key
Exploit: Install awscli (https://aws.amazon.com/cli/), set the access key and secret to environment variables, and
execute the following command: $ AWS_ACCESS_KEY_ID=[ACCESS_KEY] AWS_SECRET_ACCESS_KEY=SECRET_KEY_HERE aws sts
get-caller-identity
 AWS credentials' permissions can be determined using enumerate-IAM (https://github.com/andresriancho/enumerate-iam).
 This gives broader view of the discovered AWS credentials privileges instead of just checking S3 buckets.
 $ git clone https://github.com/andresriancho/enumerate-iam
  cd  enumerate-iam
  ./enumerate-iam.py --access-key [ACCESS_KEY] --secret-key SECRET_KEY_HERE


Matched on: ba36266055c7495ce26bb12e86c7536b4a5e00cd
Name: Datadog Application Key
Description: An Datadog Application Key
```


### Client Key
```console
shell:~$ poetry run what -r 0:1 pub68ec0cbd7d0da6770545614dfa573eec
Matched on: 6770545614
Name: Phone Number

Matched on: 677054561
Name: American Social Security Number
Description: An American Identification Number

Matched on: pub68ec0cbd7d0da6770545614dfa573eec
Name: Datadog Client Token
Description: An Datadog client token
```
