### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-alpine
+RUN apk add --no-cache git \
+    && pip install  --no-cache-dir git+https://github.com/bee-san/pyWhat \
+    && apk del git \
+    && rm -rf /var/cache/apk/*
+WORKDIR /workdir
+ENTRYPOINT [ "python", "-m", "pywhat" ]


### PR DESCRIPTION
**⚠ Pull Requests not made with this template will be automatically closed 🔥**

## Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

## Why do we need this pull request?
This PR adds Docker support so that one can choose to use pyWhat in Docker instead of installing it. A GH action should probably be added to automatically push to Docker Hub and the `README.md` file should be updated.

## What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
None.

## Copy / paste of output

Please copy and paste the output of PyWhat with your new addition using an example that tests this addition below:

```console
$ docker run --rm mavnt/pywhat "0x52908400098527886E0F7030069857D2E4169EE7"
...
Matched on: 0x52908400098527886E0F7030069857D2E4169EE7
Name: Ethereum (ETH) Wallet Address
Link:  https://etherscan.io/address/0x52908400098527886E0F7030069857D2E4169EE7
...
```

```console
$ cat file.txt
0x52908400098527886E0F7030069857D2E4169EE7
$ docker run --rm -v $(pwd):/workdir mavnt/pywhat:latest file.txt
...
Matched on: 0x52908400098527886E0F7030069857D2E4169EE7
Name: Ethereum (ETH) Wallet Address
Link:  https://etherscan.io/address/0x52908400098527886E0F7030069857D2E4169EE7
...
```

