### PR TITLE
Italian Fiscal Code regex

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -1546,6 +1546,24 @@
       }
    },
    {
+      "Name": "Italian Fiscal Code",
+      "Regex": "^([A-Za-z]{6}[0-9]{2}[ABCDEHLMPSTabcdehlmpst]{1}[0-9]{2}[A-Za-z]{1}[0-9]{3}[A-Za-z]{1})$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 0.5,
+      "URL": null,
+      "Tags": [
+         "Identifiers",
+         "Credentials"
+      ],
+      "Examples": {
+         "Valid": [
+            "RSSMRA00A01H501C"
+         ],
+         "Invalid": []
+      }
+   },
+   {
       "Name": "Phone Number",
       "Regex": "^(\\s*(?:\\+?(\\d{1,3}))?[-. (]*(\\d{3})[-. )]*(\\d{3})[-. ]*(\\d{4})(?: *x(\\d+))?\\s*)$",
       "plural_name": false,


### PR DESCRIPTION
**⚠ Pull Requests not made with this template will be automatically closed 🔥**

## Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

## Why do we need this pull request?
Regex for Italian fiscal code (https://en.wikipedia.org/wiki/Italian_fiscal_code).

## What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
None.

## Copy / paste of output

Please copy and paste the output of PyWhat with your new addition using an example that tests this addition below:

```console
$ pywhat "RSSMRA00A01H501C"
Matched on: RSSMRA00A01H501C
Name: Italian Fiscal Code
Description: https://en.wikipedia.org/wiki/Italian_fiscal_code
```
