### PR TITLE
Add support for list of regex in regex.json

### DIFF
--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -1592,6 +1592,33 @@
       }
    },
    {
+      "Name": "Phone Number",
+      "Regex": "^[0-9]([\\.\\s\\-]?\\d){6}$",
+      "plural_name": false,
+      "Description": null,
+      "Rarity": 0.5,
+      "URL": null,
+      "Tags": [
+         "Identifiers",
+         "Credentials",
+         "Phone Number",
+         "Phone",
+         "Telephone"
+      ],
+      "Children": {
+         "path": "phone_codes.json",
+         "entry": "Location(s): ",
+         "method": "hashmap"
+      },
+      "Examples": {
+         "Valid": [
+            "1234567",
+            "7777777"
+         ],
+         "Invalid": []
+      }
+   },
+   {
       "Name": "American Social Security Number",
       "Regex": "^(([0-9][0-9][0-9])(?<!666|000|9[0-9][0-9])(=|\\+|_|\\#|:|;|\\.|-|\\s){0,3}([1-9][1-9]|0[1-9]|[1-9]0)(=|\\+|_|\\#|:|;|\\.|-|\\s){0,3}([0-9][0-9][0-9][0-9])(?<!0000)(=|\\+|_|\\#|:|;|\\.|-|\\s){0,3}?)$",
       "plural_name": false,

--- a/pywhat/helper.py
+++ b/pywhat/helper.py
@@ -40,6 +40,8 @@ def read_json(path: str):
 
 @lru_cache()
 def load_regexes() -> list:
+    combined_regexes = []
+    regex_index_mapping = {}
     regexes = read_json("regex.json")
     for regex in regexes:
         regex["Boundaryless Regex"] = re.sub(
@@ -57,8 +59,35 @@ def load_regexes() -> list:
             children["lengths"] = set()
             for element in children["Items"]:
                 children["lengths"].add(len(element))
-    return regexes
-
+        # Check if multiple regex patterns present
+        regex_name = regex["Name"]
+        if(regex_name in regex_index_mapping):
+            # Update regex pattern
+            existing_regex = combined_regexes[regex_index_mapping[regex_name]]["Regex"]
+            updated_regex = existing_regex + "|" + regex["Regex"]
+            combined_regexes[regex_index_mapping[regex_name]]["Regex"] = updated_regex
+            # Combine tags
+            updated_tags = combined_regexes[regex_index_mapping[regex_name]]["Tags"]
+            for tag in regex["Tags"]:
+                if(tag not in updated_tags):
+                    updated_tags.append(tag)
+            # Combine examples
+            updated_valid_examples = combined_regexes[regex_index_mapping[regex_name]]["Examples"]["Valid"]
+            for valid_example in regex["Examples"]["Valid"]:
+                if(valid_example not in updated_valid_examples):
+                    updated_valid_examples.append(valid_example)
+            updated_invalid_examples = combined_regexes[regex_index_mapping[regex_name]]["Examples"]["Invalid"]
+            for invalid_example in regex["Examples"]["Invalid"]:
+                if(invalid_example not in updated_invalid_examples):
+                    updated_invalid_examples.append(invalid_example)
+            # Update boundaryless regex pattern
+            existing_boundaryless_regex = combined_regexes[regex_index_mapping[regex_name]]["Boundaryless Regex"]
+            updated_boundaryless_regex = existing_boundaryless_regex + "|" + regex["Boundaryless Regex"]
+            combined_regexes[regex_index_mapping[regex_name]]["Boundaryless Regex"] = updated_boundaryless_regex
+        else:
+            regex_index_mapping[regex_name] = len(combined_regexes)
+            combined_regexes.append(regex)
+    return combined_regexes
 
 class CaseInsensitiveSet(collections.abc.Set):
     def __init__(self, iterable=None):


### PR DESCRIPTION
**⚠ Pull Requests not made with this template will be automatically closed 🔥**

## Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

## Why do we need this pull request?
* The main idea is to support multiple regex patterns for the same entry. Different regex patterns for multiple entries with the same name in `regex.json` are combined dynamically , which makes individual regex easy to understand. Here for example , there can be different types of Phone Number pattern such as 10 digits, 7 digits or 11 digits; so we can have multiple entries with same Name and different regex pattern. The added code will dynamically combine such entries by vertical pipe `|`.
* Fixed #227 

## What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
* Fixes #227 

## Copy / paste of output
```
(pyWhat) C:\Users\WIN10\OneDrive\Documents\GitHub\pyWhat>python pywhat\what.py 1234567
Matched on: 1234567
Name: Phone Number
```
```
(pyWhat) C:\Users\WIN10\OneDrive\Documents\GitHub\pyWhat>python pywhat\what.py "654 2345"
Matched on: 654 2345
Name: Phone Number
```
```
(pyWhat) C:\Users\WIN10\OneDrive\Documents\GitHub\pyWhat>python pywhat\what.py "+13528880000"
Matched on: +13528880000
Name: Phone Number
Description: Location(s): United States

Matched on: 135288800
Name: American Social Security Number
Description: An American Identification Number

Matched on: 13528880000
Name: Turkish Identification Number
```
