### PR TITLE
Add Google Client ID examples and fix its regex

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,11 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          - os: macos-latest
-            python-version: "3.6"
     runs-on: ${{ matrix.os }}
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:

--- a/pywhat/Data/regex.json
+++ b/pywhat/Data/regex.json
@@ -720,8 +720,8 @@
       ]
    },
    {
-      "Name": "Google OAuth ID",
-      "Regex": "(?i)^([0-9(+-[0-9A-Za-z_]{32}.apps.googleusercontent.com)$",
+      "Name": "Google OAuth Client ID",
+      "Regex": "(?i)^([0-9]+\\-[0-9A-Z_]+\\.apps\\.googleusercontent\\.com)$",
       "plural_name": false,
       "Description": null,
       "Exploit": null,
@@ -732,7 +732,15 @@
          "Bug Bounty",
          "Credentials",
          "Google"
-      ]
+      ],
+      "Examples": {
+         "Valid": [
+            "3453453452345-dfgjw3456u2094mlfg45p.apps.googleusercontent.com",
+            "862726500644-mba83qqf9kq69c5mk9u5h2dn4iocdspq.apps.googleusercontent.com",
+            "1234567890-abc123def456.apps.googleusercontent.com"
+         ],
+         "Invalid": []
+      }
    },
    {
       "Name": "StackHawk API Key",


### PR DESCRIPTION
**⚠ Pull Requests not made with this template will be automatically closed 🔥**

## Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

## Why do we need this pull request?
* Explain the _why_ behind your PR. We can see what it does from the code. But _why_ does it do that?

This PR fixes Google Client ID regex. It had a few smaller issues which caused failures with PyWhat Rust version lemmeknow. We have also found examples, three actually, so that regex will be tested from now on.

When pushing the changes, CI failed telling me that windows-latest no longer supports Python 3.6, so I have removed Python 3.6 completely from CI as it has been EOL since December 2021.

## What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
* /

## Copy / paste of output

Please copy and paste the output of PyWhat with your new addition using an example that tests this addition below:

```console
$ poetry run pywhat "3453453452345-dfgjw3456u2094mlfg45p.apps.googleusercontent.com"

Matched on: 3453453452345-dfgjw3456u2094mlfg45p.apps.googleusercontent.com
Name: Google OAuth Client ID

Matched on: 3453453452345-dfgjw3456u2094mlfg45p.apps.googleusercontent.com
Name: Uniform Resource Locator (URL)

Matched on: 3453453452345
Name: Phone Number

Matched on: 345345345
Name: American Social Security Number
Description: An American Identification Number

Matched on: 45345345234
Name: Turkish Identification Number
```
