### PR TITLE
Remove Python 3.6 tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,11 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          - os: macos-latest
-            python-version: "3.6"
     runs-on: ${{ matrix.os }}
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The Python 3.6 CI checks don't work anymore.

**⚠ Pull Requests not made with this template will be automatically closed 🔥**

## Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

## Why do we need this pull request?
* Because Python 3.6 is deprecated and GitHub removed it from the CI so the tests don't work anymore.

## What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
* N/A

## Copy / paste of output
N/A
