### PR TITLE
Implement support for multiple input files handling

### DIFF
--- a/pywhat/what.py
+++ b/pywhat/what.py
@@ -66,7 +66,7 @@ def get_text(ctx, opts, value):
         ignore_unknown_options=True,
     )
 )
-@click.argument("text_input", callback=get_text, required=False)
+@click.argument("text_input", callback=get_text, nargs=-1)
 @click.option(
     "-t",
     "--tags",
@@ -248,7 +248,7 @@ def main(**kwargs):
         * what 'this/is/a/path'
 
     """
-    if kwargs["text_input"] is None:
+    if kwargs["text_input"] == ():
         sys.exit("Text input expected. Run 'pywhat --help' for help")
     dist = Distribution(
         create_filter(kwargs["rarity"], kwargs["include"], kwargs["exclude"])
@@ -270,25 +270,26 @@ def main(**kwargs):
         except ValueError:
             print("Invalid key")
             sys.exit(1)
-    identified_output = what_obj.what_is_this(
-        kwargs["text_input"],
-        kwargs["only_text"],
-        key,
-        kwargs["reverse"],
-        boundaryless,
-        kwargs["include_filenames"],
-    )
+    for text_input in kwargs["text_input"]:
+        identified_output = what_obj.what_is_this(
+           text_input ,
+            kwargs["only_text"],
+            key,
+            kwargs["reverse"],
+            boundaryless,
+            kwargs["include_filenames"],
+        )
 
-    p = printer.Printing()
+        p = printer.Printing()
 
-    if kwargs["json"] or str(kwargs["format"]).strip() == "json":
-        p.print_json(identified_output)
-    elif str(kwargs["format"]).strip() == "pretty":
-        p.pretty_print(identified_output, kwargs["text_input"], kwargs["print_tags"])
-    elif kwargs["format"] is not None:
-        p.format_print(identified_output, kwargs["format"])
-    else:
-        p.print_raw(identified_output, kwargs["text_input"], kwargs["print_tags"])
+        if kwargs["json"] or str(kwargs["format"]).strip() == "json":
+            p.print_json(identified_output)
+        elif str(kwargs["format"]).strip() == "pretty":
+            p.pretty_print(identified_output, text_input, kwargs["print_tags"])
+        elif kwargs["format"] is not None:
+            p.format_print(identified_output, kwargs["format"])
+        else:
+            p.print_raw(identified_output, text_input, kwargs["print_tags"])
 
 
 class What_Object:


### PR DESCRIPTION
## Prerequisites
- [X] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

## Why do we need this pull request?
This will allow pyWhat to handle being given multiple inputs.

## What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
* Fixes #171

## Copy / paste of output

Please copy and paste the output of PyWhat with your new addition using an example that tests this addition below:

```console
 what "0x52908400098527886E0F7030069857D2E4169EE7" noxfile.py
Matched on: 5290840009852
Name: Phone Number

Matched on: 7030069857
Name: Phone Number

Matched on: 529084000
Name: American Social Security Number
Description: An American Identification Number

Matched on: 030069857
Name: American Social Security Number
Description: An American Identification Number

Matched on: 5290840009852788
Name: MasterCard Number

Matched on: 0x52908400098527886E0F7030069857D2E4169EE7
Name: Ethereum (ETH) Wallet Address
Link:  https://etherscan.io/address/0x52908400098527886E0F7030069857D2E4169EE7

Matched on: 52908400098
Name: Turkish Identification Number
Matched on: nox.ses
Name: Uniform Resource Locator (URL)

Matched on: nox.options.ses
Name: Uniform Resource Locator (URL)

Matched on: environ.ge
Name: Uniform Resource Locator (URL)

Matched on: nox.options.sessions.app
Name: Uniform Resource Locator (URL)

Matched on: noxfile.py
Name: Uniform Resource Locator (URL)

Matched on: conf.py
Name: Uniform Resource Locator (URL)

Matched on: nox.sessions.Session.in
Name: Uniform Resource Locator (URL)

Matched on: Session.in
Name: Uniform Resource Locator (URL)

Matched on: session.run
Name: Uniform Resource Locator (URL)

Matched on: session.in
Name: Uniform Resource Locator (URL)

Matched on: nox.ses
Name: Uniform Resource Locator (URL)

Matched on: session.run
Name: Uniform Resource Locator (URL)

Matched on: session.run
Name: Uniform Resource Locator (URL)

Matched on: nox.ses
Name: Uniform Resource Locator (URL)

Matched on: session.run
Name: Uniform Resource Locator (URL)
```
