### PR TITLE
Fix example invocation with tags in help string

### DIFF
--- a/pywhat/what.py
+++ b/pywhat/what.py
@@ -234,7 +234,7 @@ def main(**kwargs):
 
         * what --rarity 0.6: 'myEmail@host.org'
 
-        * what --rarity 0: --include "credentials, username, password" --exclude "aws, credentials" 'James:SecretPassword'
+        * what --rarity 0: --include "credentials" --exclude "aws" 'James:SecretPassword'
 
         * what -br 0.6: -be URL '123myEmail@host.org456'
 


### PR DESCRIPTION
This PR updates the help string for example with tags - use valid and currently available tags.

I am not that familiar with all tags and regexes, so it is quite possible that provided example does not necessary shows the best capabilities of pyWhat. I was aiming to alter the example to provide at least some match, instead of warning about incorrect invocation.

So feel free to suggest more meaningful example :-)

**⚠ Pull Requests not made with this template will be automatically closed 🔥**

## Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

## Why do we need this pull request?
* Example invocation should lead to at least some result, so user might get familiar with intended usage. IMO it should not show warning about incorrect invocation.

## What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
* Fixes #253 

## Copy / paste of output

Please copy and paste the output of PyWhat with your new addition using an example that tests this addition below:

```console
$ what --rarity 0: --include "credentials" --exclude "aws" 'James:SecretPassword'
Matched on: James:SecretPassword
Name: Key:Value Pair
```
