### PR TITLE
refactor: replace os.path with pathlib.Path in helper.py

### DIFF
--- a/pywhat/helper.py
+++ b/pywhat/helper.py
@@ -1,9 +1,9 @@
 """Helper utilities"""
 import collections.abc
-import os.path
 import re
 from enum import Enum, auto
 from functools import lru_cache
+from pathlib import Path
 
 try:
     import orjson as json
@@ -33,7 +33,7 @@ class InvalidTag(Exception):
 
 @lru_cache()
 def read_json(path: str):
-    fullpath = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Data/" + path)
+    fullpath = Path(__file__).resolve().parent / "Data" / path
     with open(fullpath, "rb") as myfile:
         return json.loads(myfile.read())
 


### PR DESCRIPTION
Make the path building expression in `read_json()` less convoluted and more readable.

Replace `os.path` calls with `pathlib.Path()` object.

**⚠ Pull Requests not made with this template will be automatically closed 🔥**

## Prerequisites
- [x] Have you read the documentation on contributing? https://github.com/bee-san/pyWhat/wiki/Adding-your-own-Regex

## Why do we need this pull request?
To improve the code readability and to prevent potential mistakes in path handling code.

## What [GitHub issues](https://github.com/bee-san/pyWhat/issues) does this fix?
Nothing, just a refactoring to improve code readability.

## Copy / paste of output

No output needed, it should work the same as before the changes :)
